### PR TITLE
M4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,25 @@ env:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            deps: sudo apt-get update && sudo apt-get install -y libasound2-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libfontconfig1-dev
+          - os: windows-latest
+            deps: ""
+          - os: macos-latest
+            deps: ""
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Install system dependencies (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: ${{ matrix.deps }}
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,33 @@ env:
 
 jobs:
   build-and-release:
-    name: Build and Release macOS App
-    runs-on: macos-latest
+    name: Build and Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact_name: SR-Player-macos.zip
+            asset_name: SR-Player-${{ github.ref_name }}-macos.zip
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact_name: sr-player-linux.tar.gz
+            asset_name: sr-player-${{ github.ref_name }}-linux.tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_name: sr-player-windows.zip
+            asset_name: sr-player-${{ github.ref_name }}-windows.zip
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Install system dependencies (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libasound2-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev libfontconfig1-dev
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -34,48 +55,107 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-release-
 
-    - name: Install cargo-bundle
+    - name: Install cargo-bundle (macOS only)
+      if: matrix.os == 'macos-latest'
       run: cargo install cargo-bundle
 
     - name: Build macOS app bundle
+      if: matrix.os == 'macos-latest'
       run: cargo bundle --release
 
-    - name: Create ZIP
+    - name: Build Linux binary
+      if: matrix.os == 'ubuntu-latest'
+      run: cargo build --release
+
+    - name: Build Windows binary
+      if: matrix.os == 'windows-latest'
+      run: cargo build --release
+
+    - name: Package macOS
+      if: matrix.os == 'macos-latest'
       run: |
         cd target/release/bundle/osx
         zip -r "SR-Player-${{ github.ref_name }}-macos.zip" "SR Player.app"
         mv "SR-Player-${{ github.ref_name }}-macos.zip" ../../../..
 
-    - name: Get app size
+    - name: Package Linux
+      if: matrix.os == 'ubuntu-latest'
       run: |
-        du -sh "target/release/bundle/osx/SR Player.app"
-        ls -lh "SR-Player-${{ github.ref_name }}-macos.zip"
+        mkdir -p package
+        cp target/release/sr-player package/
+        cp README.md package/
+        tar -czf "sr-player-${{ github.ref_name }}-linux.tar.gz" -C package .
 
-    - name: Create Release and Upload Asset
+    - name: Package Windows
+      if: matrix.os == 'windows-latest'
+      shell: bash
+      run: |
+        mkdir -p package
+        cp target/release/sr-player.exe package/
+        cp README.md package/
+        cd package
+        7z a "../sr-player-${{ github.ref_name }}-windows.zip" *
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.os }}-release
+        path: |
+          SR-Player-${{ github.ref_name }}-macos.zip
+          sr-player-${{ github.ref_name }}-linux.tar.gz
+          sr-player-${{ github.ref_name }}-windows.zip
+
+  create-release:
+    name: Create Release
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+
+    - name: Create Release and Upload Assets
       uses: softprops/action-gh-release@v2
       with:
         name: SR Player ${{ github.ref_name }}
         body: |
           ## SR Player ${{ github.ref_name }}
 
-          A fast and lightweight macOS desktop app for streaming Sveriges Radio live channels.
+          A fast and lightweight desktop app for streaming Sveriges Radio live channels and podcasts.
 
           ### Features
           - Stream all Sveriges Radio live channels
+          - Browse and play podcast episodes
           - Gapless audio playback with Symphonia decoder
-          - Real-time "Now Playing" information
-          - Native macOS .app bundle (~5MB)
+          - Real-time "Now Playing" information with program details
+          - Cross-platform support (macOS, Linux, Windows)
 
           ### Installation
+
+          #### macOS
           1. Download `SR-Player-${{ github.ref_name }}-macos.zip`
           2. Unzip the file
           3. Drag `SR Player.app` to your Applications folder
           4. Right-click and select "Open" (first time only, due to macOS Gatekeeper)
 
-          ### What's Changed
-          - Initial release with gapless streaming
+          #### Linux
+          1. Download `sr-player-${{ github.ref_name }}-linux.tar.gz`
+          2. Extract: `tar -xzf sr-player-${{ github.ref_name }}-linux.tar.gz`
+          3. Run: `./sr-player`
+          4. Required dependencies: `libasound2`, `libxcb`, `libfontconfig`
+
+          #### Windows
+          1. Download `sr-player-${{ github.ref_name }}-windows.zip`
+          2. Extract the ZIP file
+          3. Run `sr-player.exe`
+
+          ### What's Changed in Milestone 4
+          - Podcast browsing and playback
+          - Cross-platform builds for macOS, Linux, and Windows
+          - Gapless streaming for both live and podcast content
           - Full Sveriges Radio API integration
-          - Optimized binary size (~5MB)
-        files: SR-Player-${{ github.ref_name }}-macos.zip
+        files: |
+          **/SR-Player-${{ github.ref_name }}-macos.zip
+          **/sr-player-${{ github.ref_name }}-linux.tar.gz
+          **/sr-player-${{ github.ref_name }}-windows.zip
         draft: false
         prerelease: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4898,6 +4898,7 @@ dependencies = [
  "chrono",
  "crossbeam-channel",
  "env_logger",
+ "image",
  "log",
  "reqwest",
  "rodio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,6 +3821,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4896,6 +4924,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
+ "chrono-tz",
  "crossbeam-channel",
  "env_logger",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = "0.11"
 log = "0.4"
 crossbeam-channel = "0.5"
 chrono = "0.4"
+chrono-tz = "0.10"
 image = "0.25"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ env_logger = "0.11"
 log = "0.4"
 crossbeam-channel = "0.5"
 chrono = "0.4"
+image = "0.25"
 
 [build-dependencies]
 slint-build = "1.9"

--- a/README.md
+++ b/README.md
@@ -4,28 +4,40 @@
 [![Release](https://img.shields.io/github/v/release/wlinds/SR-Player?include_prereleases)](https://github.com/wlinds/SR-Player/releases)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 
-A super fast and lightweight macOS (soon cross-platform) desktop app for streaming Sveriges Radio live channels, built with Rust, Slint, Symphonia and Rodio.
+A super fast and lightweight cross-platform desktop app for streaming Sveriges Radio live channels and podcasts, built with Rust, Slint, Symphonia and Rodio.
 
 
 ![alt text](images/sr-player-025-11-04.png)
 
-## Live Features
+## Features
 
+### Live Radio
 - Stream all Sveriges Radio live channels
 - Gapless and super fast audio playback
 - Real-time "Now Playing" information
 - Quick channel browsing
+
+### Podcasts
+- Browse and listen to programs and podcasts
+
+### Cross-Platform
 - Native macOS .app bundle (~5MB)
+- Linux binary with minimal dependencies
+- Windows executable
 
-## Current Status: Milestone 3 Complete
+## Current Status: Milestone 4 Complete
 
-The code is extensively commented and easy for new Rust developers to get into, possibly comming from Python or JavaScript.
+The code is extensively commented and easy for new Rust developers to get into, possibly coming from Python or JavaScript.
 
 **Working:**
 - Gapless streaming using Symphonia decoder
 - Fetch and display all Sveriges Radio channels from API
-- Real-time "Now Playing" program information from SR API
-- Native macOS .app
+- Real-time "Now Playing" program information (auto-updates every 30s)
+- Stockholm timezone support (handles CET/CEST automatically)
+- Browse and play podcast episodes (25 most recent, server-side sorted)
+- Tabbed UI for Live channels, Podcasts, and News
+- Collapsible groups for P4 Local News and Ekot News
+- Cross-platform builds (macOS, Linux, Windows)
 - Optimized release builds (~5MB total size)
 - Thread-safe async streaming architecture
 
@@ -41,12 +53,34 @@ The code is extensively commented and easy for new Rust developers to get into, 
 
 ## Installation
 
-### Download Pre-built Binary (Easy macOS Installation)
+### Download Pre-built Binaries
 
+#### macOS
 1. Go to [Releases](https://github.com/wlinds/SR-Player/releases)
-2. Download `SR-Player-v0.1.0-macos.zip`
+2. Download `SR-Player-vX.X.X-macos.zip`
 3. Unzip and drag `SR Player.app` to Applications
 4. Right-click and select "Open" (first time only, due to macOS Gatekeeper)
+
+#### Linux
+1. Go to [Releases](https://github.com/wlinds/SR-Player/releases)
+2. Download `sr-player-vX.X.X-linux.tar.gz`
+3. Extract: `tar -xzf sr-player-vX.X.X-linux.tar.gz`
+4. Run: `./sr-player`
+
+**Linux Dependencies:**
+```bash
+# Debian/Ubuntu
+sudo apt-get install libasound2 libxcb-render0 libxcb-shape0 libxcb-xfixes0 libxkbcommon0 libfontconfig1
+
+# Fedora/RHEL
+sudo dnf install alsa-lib libxcb libxkbcommon fontconfig
+```
+
+#### Windows
+1. Go to [Releases](https://github.com/wlinds/SR-Player/releases)
+2. Download `sr-player-vX.X.X-windows.zip`
+3. Extract the ZIP file
+4. Run `sr-player.exe`
 
 ### Build from Source
 
@@ -58,7 +92,9 @@ cargo run
 
 [Syntax highlighting in VSCode for Slint](https://marketplace.visualstudio.com/items?itemName=Slint.slint)
 
-**Production Build (macOS App):**
+**Production Builds:**
+
+**macOS (App Bundle):**
 ```bash
 # Install cargo-bundle (first time only)
 cargo install cargo-bundle
@@ -67,6 +103,22 @@ cargo install cargo-bundle
 cargo bundle --release
 
 # Result: target/release/bundle/osx/SR Player.app
+```
+
+**Linux:**
+```bash
+# Build optimized binary
+cargo build --release
+
+# Result: target/release/sr-player
+```
+
+**Windows:**
+```bash
+# Build optimized binary
+cargo build --release
+
+# Result: target/release/sr-player.exe
 ```
 
 ## Binary Size Optimization
@@ -91,9 +143,22 @@ panic = "abort"       # Remove unwinding machinery
 
 **Gapless Streaming:**
 - HTTP Stream → Custom MediaSource → Symphonia Decoder → Rodio Sink
+- Supports both live radio streams (AAC) and podcast episodes (MP3)
 - Dedicated audio thread for thread-safe non-Send types
 - Async HTTP streaming with tokio
 - Eliminates gaps between audio chunks
+
+**UI Framework:**
+- Slint 1.9 for native cross-platform UI
+- Declarative component-based architecture
+- Compiles to native code (no web runtime)
+
+**API Integration:**
+- Sveriges Radio Open API for channels, schedules, programs, and podcasts
+- Episodes endpoint (not podfiles) for reliable server-side sorting
+- Async data fetching with lazy loading for performance
+- Image decoding and display for program artwork
+- Automatic timezone conversion (UTC → Stockholm)
 
 ---
 

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,10 @@ fn main() {
     // - We can use it in main.rs like: slint::include_modules!();
 
     println!("cargo:rerun-if-changed=src/ui/main.slint");
+    println!("cargo:rerun-if-changed=src/ui/types.slint");
+    println!("cargo:rerun-if-changed=src/ui/now_playing.slint");
+    println!("cargo:rerun-if-changed=src/ui/tab_content.slint");
+    println!("cargo:rerun-if-changed=src/ui/tab_bar.slint");
     // This tells Cargo: "If main.slint changes, run build.rs again"
     // Like file watching in webpack or nodemon
 }

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -204,14 +204,10 @@ impl SrApiClient {
 
         debug!("Fetching podcast episodes from: {}", url);
 
-        let response = self
-            .client
-            .get(&url)
-            .send()
-            .context(format!(
-                "Failed to fetch podcast episodes for program {}",
-                program_id
-            ))?;
+        let response = self.client.get(&url).send().context(format!(
+            "Failed to fetch podcast episodes for program {}",
+            program_id
+        ))?;
 
         let episodes_response: EpisodesResponse = response
             .json()

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -1,11 +1,19 @@
 // This module handles all communication with the Sveriges Radio API
 // https://www.sverigesradio.se/oppetapi
-// We use the 'reqwest' library to make HTTP requests and 'anyhow' for error handling.
+//
+// This module handles all HTTP communication with the SR API endpoints.
+// We use:
+// - reqwest: For making HTTP requests (blocking client for simplicity)
+// - anyhow: For ergonomic error handling with context
+// - serde: For JSON deserialization into our model structs
 
 use anyhow::{Context, Result};
 use log::{debug, info};
 
-use crate::core::models::{Channel, ChannelsResponse, ScheduleRightNowResponse};
+use crate::core::models::{
+    Channel, ChannelsResponse, EpisodesResponse, PodFile, Program, ProgramsResponse,
+    ScheduleRightNowResponse,
+};
 
 // Base URL for all Sveriges Radio API endpoints
 const SR_API_BASE: &str = "https://api.sr.se/api/v2";
@@ -16,8 +24,8 @@ const SR_API_BASE: &str = "https://api.sr.se/api/v2";
 
 /// The main API client that handles all requests to Sveriges Radio
 ///
-/// In Rust, we use a struct to group related data and functionality.
-/// This client uses reqwest's blocking client, which means it will wait for the HTTP request to complete before continuing (simpler for beginners).
+/// Uses a blocking HTTP client for simplicity. All methods are synchronous and should
+/// be called from within tokio::task::spawn_blocking when used in async contexts.
 #[derive(Clone)]
 pub struct SrApiClient {
     client: reqwest::blocking::Client, // The HTTP client that makes requests
@@ -127,6 +135,123 @@ impl SrApiClient {
         );
 
         Ok(schedule_response)
+    }
+
+    /// Fetches all programs with podcasts available
+    ///
+    /// Returns a Vec of Program structs filtered to only include those with podcasts
+    ///
+    /// Example:
+    /// ```
+    /// let programs = client.get_programs_with_podcasts()?;
+    /// for program in programs {
+    ///     println!("Program: {} (ID: {})", program.name, program.id);
+    /// }
+    /// ```
+    pub fn get_programs_with_podcasts(&self) -> Result<Vec<Program>> {
+        // Fetch all programs without pagination (all results at once)
+        // We'll filter for has_pod=true after fetching
+        let url = format!("{}/programs?format=json&pagination=false", SR_API_BASE);
+
+        debug!("Fetching programs from: {}", url);
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .context("Failed to fetch programs")?;
+
+        let programs_response: ProgramsResponse = response
+            .json()
+            .context("Failed to parse programs JSON response")?;
+
+        // Filter to only include programs that have podcasts and are not archived
+        let podcast_programs: Vec<Program> = programs_response
+            .programs
+            .into_iter()
+            .filter(|p| p.has_pod && !p.archived)
+            .collect();
+
+        info!(
+            "Successfully fetched {} programs with podcasts",
+            podcast_programs.len()
+        );
+
+        Ok(podcast_programs)
+    }
+
+    /// Fetches the 25 most recent podcast episodes for a specific program
+    ///
+    /// Uses the episodes/index endpoint (not podfiles) which supports reliable server-side sorting.
+    /// Episodes are sorted by publish date (newest first) and limited to 25 results.
+    ///
+    /// Returns a Vec of PodFile structs (converted from Episode objects)
+    ///
+    /// Example:
+    /// ```
+    /// let episodes = client.get_podcast_episodes(4916)?;
+    /// for episode in episodes {
+    ///     println!("Episode: {} - Duration: {}s", episode.title, episode.duration);
+    /// }
+    /// ```
+    pub fn get_podcast_episodes(&self, program_id: u32) -> Result<Vec<PodFile>> {
+        // Use episodes/index endpoint for reliable server-side sorting
+        // sort=publishdateutc%2Bdesc (%2B = URL-encoded '+') gives newest episodes first
+        let url = format!(
+            "{}/episodes/index?programid={}&format=json&pagination=true&page=1&size=25&sort=publishdateutc%2Bdesc",
+            SR_API_BASE, program_id
+        );
+
+        debug!("Fetching podcast episodes from: {}", url);
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .context(format!(
+                "Failed to fetch podcast episodes for program {}",
+                program_id
+            ))?;
+
+        let episodes_response: EpisodesResponse = response
+            .json()
+            .context("Failed to parse podcast episodes JSON response")?;
+
+        info!(
+            "Fetched {} podcast episodes for program {} (server-side sorted)",
+            episodes_response.episodes.len(),
+            program_id
+        );
+
+        // Convert Episode objects to PodFile format
+        // Episodes have a listen_podfile field that contains the audio file info
+        let podfiles: Vec<PodFile> = episodes_response
+            .episodes
+            .into_iter()
+            .filter_map(|episode| {
+                // Only include episodes that have an actual podcast file
+                episode.listen_podfile.map(|podfile| {
+                    let publish_date = podfile.publish_date_utc.clone();
+                    PodFile {
+                        id: episode.id,
+                        title: episode.title,
+                        description: episode.description,
+                        url: podfile.url,
+                        file_size_in_bytes: podfile.file_size_in_bytes,
+                        duration: podfile.duration,
+                        publish_date_utc: podfile.publish_date_utc,
+                        available_from_utc: publish_date, // Same as publish date for episodes
+                        program: crate::core::models::ProgramInfo {
+                            id: program_id,
+                            name: None,
+                        },
+                        stat_key: None,
+                    }
+                })
+            })
+            .collect();
+
+        Ok(podfiles)
     }
 }
 

--- a/src/core/gapless_streaming.rs
+++ b/src/core/gapless_streaming.rs
@@ -617,7 +617,6 @@ impl GaplessPlayer {
                 }
                 Err(e) => {
                     error!("Timeout waiting for initial data: {}", e);
-                    return;
                 }
             }
         });

--- a/src/core/gapless_streaming.rs
+++ b/src/core/gapless_streaming.rs
@@ -528,7 +528,10 @@ impl GaplessPlayer {
                 }
             }
 
-            info!("Initial buffer complete ({} bytes), starting playback...", initial_buffer.len());
+            info!(
+                "Initial buffer complete ({} bytes), starting playback...",
+                initial_buffer.len()
+            );
 
             // Send the buffered data immediately
             if data_tx.send(Bytes::from(initial_buffer)).is_err() {
@@ -585,7 +588,10 @@ impl GaplessPlayer {
             // This ensures we have data to probe when Symphonia initializes
             match data_rx.recv_timeout(Duration::from_secs(1)) {
                 Ok(first_chunk) => {
-                    info!("Received first chunk ({} bytes), creating decoder...", first_chunk.len());
+                    info!(
+                        "Received first chunk ({} bytes), creating decoder...",
+                        first_chunk.len()
+                    );
 
                     // Create our custom media source with the first chunk already received
                     let mut media_source = Box::new(ChannelMediaSource::new(data_rx));

--- a/src/core/gapless_streaming.rs
+++ b/src/core/gapless_streaming.rs
@@ -507,7 +507,7 @@ impl GaplessPlayer {
             let mut bytes_downloaded = 0;
             let start_time = Instant::now();
             let mut initial_buffer = Vec::new();
-            const INITIAL_BUFFER_SIZE: usize = 32_768; // 32KB initial buffer
+            const INITIAL_BUFFER_SIZE: usize = 8_192; // 8KB initial buffer
 
             // Buffer initial chunks before starting decoder
             // This prevents "EOF at 0 bytes" errors and ensures smooth startup

--- a/src/core/gapless_streaming.rs
+++ b/src/core/gapless_streaming.rs
@@ -502,12 +502,41 @@ impl GaplessPlayer {
                 }
             };
 
-            info!("Connected to stream, starting download...");
+            info!("Connected to stream, buffering initial data...");
 
             let mut bytes_downloaded = 0;
             let start_time = Instant::now();
+            let mut initial_buffer = Vec::new();
+            const INITIAL_BUFFER_SIZE: usize = 32_768; // 32KB initial buffer
 
-            // Stream bytes continuously
+            // Buffer initial chunks before starting decoder
+            // This prevents "EOF at 0 bytes" errors and ensures smooth startup
+            while initial_buffer.len() < INITIAL_BUFFER_SIZE {
+                match response.chunk().await {
+                    Ok(Some(chunk)) => {
+                        bytes_downloaded += chunk.len();
+                        initial_buffer.extend_from_slice(&chunk);
+                    }
+                    Ok(None) => {
+                        error!("Stream ended while buffering initial data");
+                        return;
+                    }
+                    Err(e) => {
+                        error!("Error reading initial chunk: {}", e);
+                        return;
+                    }
+                }
+            }
+
+            info!("Initial buffer complete ({} bytes), starting playback...", initial_buffer.len());
+
+            // Send the buffered data immediately
+            if data_tx.send(Bytes::from(initial_buffer)).is_err() {
+                error!("Failed to send initial buffer");
+                return;
+            }
+
+            // Stream remaining bytes continuously
             while let Some(chunk_result) = response.chunk().await.transpose() {
                 // Check for stop command (non-blocking)
                 if let Ok(StreamCommand::Stop) = command_rx.try_recv() {

--- a/src/core/gapless_streaming.rs
+++ b/src/core/gapless_streaming.rs
@@ -550,26 +550,41 @@ impl GaplessPlayer {
         // Spawn decoder task
         let sink_clone = sink.clone();
         tokio::task::spawn_blocking(move || {
-            info!("Decoder task started");
+            info!("Decoder task started, waiting for initial data...");
 
-            // Create our custom media source from the channel
-            let media_source = Box::new(ChannelMediaSource::new(data_rx));
+            // Wait for first chunk to arrive before creating Symphonia source
+            // This ensures we have data to probe when Symphonia initializes
+            match data_rx.recv_timeout(Duration::from_secs(1)) {
+                Ok(first_chunk) => {
+                    info!("Received first chunk ({} bytes), creating decoder...", first_chunk.len());
 
-            // Create Symphonia source
-            let symphonia_source = match SymphoniaSource::new(media_source) {
-                Ok(source) => source,
+                    // Create our custom media source with the first chunk already received
+                    let mut media_source = Box::new(ChannelMediaSource::new(data_rx));
+                    // Store the first chunk in the media source
+                    media_source.current_chunk = Some(first_chunk);
+                    media_source.current_position = 0;
+
+                    // Create Symphonia source - now it has data to probe
+                    let symphonia_source = match SymphoniaSource::new(media_source) {
+                        Ok(source) => source,
+                        Err(e) => {
+                            error!("Failed to create Symphonia source: {}", e);
+                            return;
+                        }
+                    };
+
+                    // Append to sink and play!
+                    let sink_guard = tokio::runtime::Handle::current().block_on(sink_clone.lock());
+                    sink_guard.append(symphonia_source);
+                    sink_guard.play();
+
+                    info!("Playback started!");
+                }
                 Err(e) => {
-                    error!("Failed to create Symphonia source: {}", e);
+                    error!("Timeout waiting for initial data: {}", e);
                     return;
                 }
-            };
-
-            // Append to sink and play!
-            let sink_guard = tokio::runtime::Handle::current().block_on(sink_clone.lock());
-            sink_guard.append(symphonia_source);
-            sink_guard.play();
-
-            info!("Playback started!");
+            }
         });
 
         Ok(())

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -23,4 +23,6 @@
 pub mod api; // Exposes core/api.rs - API client for Sveriges Radio
 pub mod gapless_send_safe;
 pub mod gapless_streaming; // Exposes core/gapless_streaming.rs - Gapless player with Symphonia
-pub mod models; // Exposes core/models.rs - Data structures for API responses // Exposes core/gapless_send_safe.rs - Send-safe wrapper
+pub mod models; // Exposes core/models.rs - Data structures for API responses
+pub mod podcast; // Exposes core/podcast.rs - Podcast handling utilities
+pub mod utils; // Exposes core/utils.rs - Utility functions for image and date handling

--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -140,3 +140,151 @@ pub struct ProgramInfo {
     pub id: u32,
     pub name: Option<String>, // Name might be missing
 }
+
+// ============================================================================
+// PROGRAMS API MODELS (for podcasts)
+// ============================================================================
+
+// Response from the programs API endpoint
+// Example: https://api.sr.se/api/v2/programs?format=json
+//
+// This gives us all programs, including which ones have podcasts available
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgramsResponse {
+    pub programs: Vec<Program>,
+    pub copyright: String,
+    pub pagination: Option<Pagination>,
+}
+
+// Represents a Sveriges Radio program (show)
+// Programs can be either live broadcasts or have podcast episodes available
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Program {
+    pub id: u32,
+    pub name: String,
+    pub description: Option<String>,
+
+    #[serde(rename = "programurl")]
+    pub program_url: Option<String>,
+
+    #[serde(rename = "programimage")]
+    pub program_image: Option<String>,
+
+    #[serde(rename = "programimagetemplate")]
+    pub program_image_template: Option<String>,
+
+    #[serde(rename = "programimagewide")]
+    pub program_image_wide: Option<String>,
+
+    #[serde(rename = "socialimage")]
+    pub social_image: Option<String>,
+
+    pub email: Option<String>,
+    pub phone: Option<String>,
+
+    pub channel: Option<ProgramChannel>,
+
+    #[serde(rename = "haspod")]
+    pub has_pod: bool, // IMPORTANT: tells us if this program has podcasts
+
+    #[serde(rename = "hasondemand")]
+    pub has_on_demand: bool, // Whether program has on-demand content
+
+    pub archived: bool, // Whether the program is archived (no longer active)
+
+    #[serde(rename = "programcategory", default)]
+    pub program_category: Option<ProgramCategory>,
+}
+
+// Channel information within a program
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgramChannel {
+    pub id: u32,
+    pub name: String,
+}
+
+// Program category (e.g., Music, Sport, News)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProgramCategory {
+    pub id: u32,
+    pub name: String,
+}
+
+// ============================================================================
+// PODCAST FILES API MODELS
+// ============================================================================
+
+// Represents a single podcast episode
+// Note: We now fetch episodes using the episodes/index endpoint (see EpisodesResponse below),
+// but convert them to PodFile format for backward compatibility with the rest of the codebase.
+// TODO: Simplify
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PodFile {
+    pub id: u32,
+    pub title: String,
+    pub description: Option<String>,
+    pub url: String, // THE IMPORTANT ONE: URL to the MP3 file
+
+    #[serde(rename = "filesizeinbytes")]
+    pub file_size_in_bytes: u64, // Size of the podcast file
+
+    pub duration: u32, // Duration in seconds
+
+    #[serde(rename = "publishdateutc")]
+    pub publish_date_utc: String, // Publish date in /Date(ms)/ format
+
+    #[serde(rename = "availablefromutc")]
+    pub available_from_utc: String, // When the episode became available
+
+    pub program: ProgramInfo, // Associated program info
+
+    #[serde(rename = "statkey")]
+    pub stat_key: Option<String>,
+}
+
+// ============================================================================
+// EPISODES API MODELS
+// ============================================================================
+
+// Response from the episodes/index API endpoint
+// Example: https://api.sr.se/api/v2/episodes/index?programid=3718&format=json
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EpisodesResponse {
+    pub episodes: Vec<Episode>,
+    pub copyright: String,
+    pub pagination: Option<Pagination>,
+}
+
+// Represents a single episode from the episodes endpoint
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Episode {
+    pub id: u32,
+    pub title: String,
+    pub description: Option<String>,
+
+    #[serde(rename = "publishdateutc")]
+    pub publish_date_utc: String,
+
+    pub url: String,
+
+    #[serde(rename = "imageurl")]
+    pub image_url: Option<String>,
+
+    #[serde(rename = "listenpodfile")]
+    pub listen_podfile: Option<EpisodePodFile>,
+}
+
+// Podfile information within an episode
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EpisodePodFile {
+    pub title: String,
+    pub description: Option<String>,
+    pub url: String,
+    pub duration: u32,
+
+    #[serde(rename = "filesizeinbytes")]
+    pub file_size_in_bytes: u64,
+
+    #[serde(rename = "publishdateutc")]
+    pub publish_date_utc: String,
+}

--- a/src/core/podcast.rs
+++ b/src/core/podcast.rs
@@ -1,0 +1,253 @@
+// Podcast Module - Helper functions for podcast/program management
+//
+// This module provides utility functions for:
+// - Fetching programs and episodes from the SR API
+// - Converting API models (Program, PodFile) to UI models (ProgramItem, EpisodeItem)
+// - Organizing programs into groups (Podcasts vs News tabs)
+// - Handling expandable groups (P4 Local News, Ekot News)
+
+use anyhow::Result;
+use slint::Image;
+
+use crate::core::api::SrApiClient;
+use crate::core::models::{PodFile, Program};
+use crate::{EpisodeItem, ProgramItem};
+
+/// Parse SR API date format /Date(milliseconds)/ and convert to a readable format
+/// Example: "/Date(1762431000000)/" -> "11 Aug 2020"
+fn parse_sr_date_to_display(date_str: &str) -> String {
+    use chrono::DateTime;
+
+    if let Some(ms_str) = date_str
+        .strip_prefix("/Date(")
+        .and_then(|s| s.strip_suffix(")/"))
+    {
+        if let Ok(ms) = ms_str.parse::<i64>() {
+            if let Some(dt) = DateTime::from_timestamp_millis(ms) {
+                return dt.format("%d %b %Y").to_string();
+            }
+        }
+    }
+    String::from("Unknown")
+}
+
+/// Convert a PodFile to an EpisodeItem (for Slint UI)
+pub fn episode_to_item(episode: &PodFile) -> Option<EpisodeItem> {
+    i32::try_from(episode.id).ok().map(|id| {
+        // Format file size (bytes to MB)
+        let file_size_mb = episode.file_size_in_bytes as f64 / 1_048_576.0;
+        let file_size_str = format!("{:.1} MB", file_size_mb);
+
+        // Format publish date
+        let publish_date = parse_sr_date_to_display(&episode.publish_date_utc);
+
+        EpisodeItem {
+            id,
+            title: episode.title.clone().into(),
+            description: episode.description.clone().unwrap_or_default().into(),
+            duration: episode.duration as i32,
+            publish_date: publish_date.into(),
+            url: episode.url.clone().into(),
+            file_size: file_size_str.into(),
+        }
+    })
+}
+
+/// Fetch all programs with podcasts and return the raw Program data
+pub async fn fetch_programs_with_podcasts(
+    api_client: &SrApiClient,
+) -> Result<Vec<Program>> {
+    let api_clone = api_client.clone();
+
+    let programs = tokio::task::spawn_blocking(move || api_clone.get_programs_with_podcasts())
+        .await??;
+
+    println!("Fetched {} programs with podcasts", programs.len());
+
+    Ok(programs)
+}
+
+/// Convert programs to ProgramItems for Podcasts tab
+///
+/// Filters out news programs (P4 Local, Ekot) which belong in the News tab.
+/// All podcast programs are shown as regular items (no grouping).
+pub fn programs_to_items_podcasts(programs: &[Program]) -> Vec<ProgramItem> {
+    let mut result = Vec::new();
+
+    // Filter out P4 and Ekot programs (they belong in News tab)
+    let non_news_programs: Vec<_> = programs
+        .iter()
+        .filter(|p| {
+            !p.name.starts_with("Nyheter P4 ") &&
+            !p.name.starts_with("Ekot") &&
+            !p.name.contains("Ekonomiekot")
+        })
+        .collect();
+
+    // Add all non-news programs
+    for program in non_news_programs {
+        if let Ok(id) = i32::try_from(program.id) {
+            let description = program
+                .description
+                .clone()
+                .unwrap_or_default()
+                .chars()
+                .take(50)
+                .collect::<String>();
+
+            result.push(ProgramItem {
+                id,
+                name: program.name.clone().into(),
+                description: description.into(),
+                image: Image::default(),
+                has_pod: program.has_pod,
+                is_group: false,
+                is_expanded: true, // Regular programs are always visible
+                is_child: false,
+                group_id: 0,
+                group_expanded: false, // Not a group
+            });
+        }
+    }
+
+    result
+}
+
+/// Convert programs to ProgramItems for News tab with expandable grouping
+///
+/// Creates two collapsible groups:
+/// 1. "Ekot News" (group_id: -2) - Contains Ekot and Ekonomiekot programs
+/// 2. "P4 Local News" (group_id: -1) - Contains all regional P4 news programs
+///
+/// The groups_expanded HashMap tracks which groups are currently expanded.
+pub fn programs_to_items_news(programs: &[Program], groups_expanded: &std::collections::HashMap<i32, bool>) -> Vec<ProgramItem> {
+    let mut result = Vec::new();
+
+    // Separate P4, Ekot, and other programs
+    let (p4_programs, remaining): (Vec<_>, Vec<_>) = programs
+        .iter()
+        .partition(|p| p.name.starts_with("Nyheter P4 "));
+
+    let (ekot_programs, _other_programs): (Vec<&Program>, Vec<&Program>) = remaining
+        .into_iter()
+        .partition(|p| p.name.starts_with("Ekot") || p.name.contains("Ekonomiekot"));
+
+    // Add Ekot group first (news at top)
+    if !ekot_programs.is_empty() {
+        let ekot_group_id = -2; // Use negative ID for groups (different from P4)
+        let ekot_expanded = groups_expanded.get(&ekot_group_id).copied().unwrap_or(false);
+
+        // Add Ekot group header
+        result.push(ProgramItem {
+            id: ekot_group_id,
+            name: "Ekot News".into(),
+            description: "".into(),
+            image: Image::default(),
+            has_pod: true,
+            is_group: true,
+            is_expanded: true, // Group headers are always visible
+            is_child: false,
+            group_id: 0,
+            group_expanded: ekot_expanded, // Shows the expansion state
+        });
+
+        // Add Ekot children if expanded
+        if ekot_expanded {
+            for program in ekot_programs {
+                if let Ok(id) = i32::try_from(program.id) {
+                    result.push(ProgramItem {
+                        id,
+                        name: program.name.clone().into(),
+                        description: "News podcasts".into(),
+                        image: Image::default(),
+                        has_pod: program.has_pod,
+                        is_group: false,
+                        is_expanded: ekot_expanded, // Child visibility depends on parent group state
+                        is_child: true,
+                        group_id: ekot_group_id,
+                        group_expanded: false, // Children are not groups
+                    });
+                }
+            }
+        }
+    }
+
+    // Add P4 group if there are P4 programs
+    if !p4_programs.is_empty() {
+        let p4_group_id = -1; // Use negative ID for groups
+        let p4_expanded = groups_expanded.get(&p4_group_id).copied().unwrap_or(false);
+
+        // Add P4 group header
+        result.push(ProgramItem {
+            id: p4_group_id,
+            name: "P4 Local News".into(),
+            description: "".into(),
+            image: Image::default(),
+            has_pod: true,
+            is_group: true,
+            is_expanded: true, // Group headers are always visible
+            is_child: false,
+            group_id: 0,
+            group_expanded: p4_expanded, // Shows the expansion state
+        });
+
+        // Add P4 children if expanded
+        if p4_expanded {
+            for program in p4_programs {
+                if let Ok(id) = i32::try_from(program.id) {
+                    let region_name = program.name
+                        .strip_prefix("Nyheter P4 ")
+                        .unwrap_or(&program.name);
+
+                    result.push(ProgramItem {
+                        id,
+                        name: region_name.to_string().into(),
+                        description: "Local news podcasts".into(),
+                        image: Image::default(),
+                        has_pod: program.has_pod,
+                        is_group: false,
+                        is_expanded: p4_expanded, // Child visibility depends on parent group state
+                        is_child: true,
+                        group_id: p4_group_id,
+                        group_expanded: false, // Children are not groups
+                    });
+                }
+            }
+        }
+    }
+
+    // News tab only shows Ekot and P4 programs, no other podcasts
+    result
+}
+
+/// Fetch episodes for a specific program and return as EpisodeItem vector
+pub async fn fetch_episodes_for_program(
+    api_client: &SrApiClient,
+    program_id: u32,
+) -> Result<(Vec<EpisodeItem>, String)> {
+    let api_clone = api_client.clone();
+
+    let episodes = tokio::task::spawn_blocking(move || api_clone.get_podcast_episodes(program_id))
+        .await??;
+
+    println!("Fetched {} episodes for program {}", episodes.len(), program_id);
+
+    // Convert to Slint EpisodeItem structs
+    let episode_items: Vec<EpisodeItem> = episodes
+        .iter()
+        .filter_map(episode_to_item)
+        .collect();
+
+    // Get program name for the header
+    let program_name = if !episodes.is_empty() {
+        episodes[0]
+            .program
+            .name
+            .clone()
+            .unwrap_or_else(|| String::from("Podcast"))
+    } else {
+        String::from("Podcast")
+    };
+
+    Ok((episode_items, program_name))
+}

--- a/src/core/podcast.rs
+++ b/src/core/podcast.rs
@@ -54,13 +54,11 @@ pub fn episode_to_item(episode: &PodFile) -> Option<EpisodeItem> {
 }
 
 /// Fetch all programs with podcasts and return the raw Program data
-pub async fn fetch_programs_with_podcasts(
-    api_client: &SrApiClient,
-) -> Result<Vec<Program>> {
+pub async fn fetch_programs_with_podcasts(api_client: &SrApiClient) -> Result<Vec<Program>> {
     let api_clone = api_client.clone();
 
-    let programs = tokio::task::spawn_blocking(move || api_clone.get_programs_with_podcasts())
-        .await??;
+    let programs =
+        tokio::task::spawn_blocking(move || api_clone.get_programs_with_podcasts()).await??;
 
     println!("Fetched {} programs with podcasts", programs.len());
 
@@ -78,9 +76,9 @@ pub fn programs_to_items_podcasts(programs: &[Program]) -> Vec<ProgramItem> {
     let non_news_programs: Vec<_> = programs
         .iter()
         .filter(|p| {
-            !p.name.starts_with("Nyheter P4 ") &&
-            !p.name.starts_with("Ekot") &&
-            !p.name.contains("Ekonomiekot")
+            !p.name.starts_with("Nyheter P4 ")
+                && !p.name.starts_with("Ekot")
+                && !p.name.contains("Ekonomiekot")
         })
         .collect();
 
@@ -120,7 +118,10 @@ pub fn programs_to_items_podcasts(programs: &[Program]) -> Vec<ProgramItem> {
 /// 2. "P4 Local News" (group_id: -1) - Contains all regional P4 news programs
 ///
 /// The groups_expanded HashMap tracks which groups are currently expanded.
-pub fn programs_to_items_news(programs: &[Program], groups_expanded: &std::collections::HashMap<i32, bool>) -> Vec<ProgramItem> {
+pub fn programs_to_items_news(
+    programs: &[Program],
+    groups_expanded: &std::collections::HashMap<i32, bool>,
+) -> Vec<ProgramItem> {
     let mut result = Vec::new();
 
     // Separate P4, Ekot, and other programs
@@ -135,7 +136,10 @@ pub fn programs_to_items_news(programs: &[Program], groups_expanded: &std::colle
     // Add Ekot group first (news at top)
     if !ekot_programs.is_empty() {
         let ekot_group_id = -2; // Use negative ID for groups (different from P4)
-        let ekot_expanded = groups_expanded.get(&ekot_group_id).copied().unwrap_or(false);
+        let ekot_expanded = groups_expanded
+            .get(&ekot_group_id)
+            .copied()
+            .unwrap_or(false);
 
         // Add Ekot group header
         result.push(ProgramItem {
@@ -195,7 +199,8 @@ pub fn programs_to_items_news(programs: &[Program], groups_expanded: &std::colle
         if p4_expanded {
             for program in p4_programs {
                 if let Ok(id) = i32::try_from(program.id) {
-                    let region_name = program.name
+                    let region_name = program
+                        .name
                         .strip_prefix("Nyheter P4 ")
                         .unwrap_or(&program.name);
 
@@ -227,16 +232,17 @@ pub async fn fetch_episodes_for_program(
 ) -> Result<(Vec<EpisodeItem>, String)> {
     let api_clone = api_client.clone();
 
-    let episodes = tokio::task::spawn_blocking(move || api_clone.get_podcast_episodes(program_id))
-        .await??;
+    let episodes =
+        tokio::task::spawn_blocking(move || api_clone.get_podcast_episodes(program_id)).await??;
 
-    println!("Fetched {} episodes for program {}", episodes.len(), program_id);
+    println!(
+        "Fetched {} episodes for program {}",
+        episodes.len(),
+        program_id
+    );
 
     // Convert to Slint EpisodeItem structs
-    let episode_items: Vec<EpisodeItem> = episodes
-        .iter()
-        .filter_map(episode_to_item)
-        .collect();
+    let episode_items: Vec<EpisodeItem> = episodes.iter().filter_map(episode_to_item).collect();
 
     // Get program name for the header
     let program_name = if !episodes.is_empty() {

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -26,7 +26,6 @@ pub fn parse_sr_date_to_time(date_str: &str) -> String {
     String::from("--:--")
 }
 
-
 /// Download image bytes from a URL
 ///
 /// Returns raw bytes which are Send-safe for use across threads.
@@ -53,11 +52,8 @@ pub fn bytes_to_slint_image(bytes: Vec<u8>) -> Option<Image> {
         Ok(img) => {
             let rgba = img.to_rgba8();
             let (width, height) = rgba.dimensions();
-            let buffer = slint::SharedPixelBuffer::clone_from_slice(
-                &rgba.into_raw(),
-                width,
-                height,
-            );
+            let buffer =
+                slint::SharedPixelBuffer::clone_from_slice(&rgba.into_raw(), width, height);
             Some(Image::from_rgba8(buffer))
         }
         Err(e) => {
@@ -65,12 +61,4 @@ pub fn bytes_to_slint_image(bytes: Vec<u8>) -> Option<Image> {
             None
         }
     }
-}
-
-/// Download and convert image in one call (convenience function)
-///
-/// Use this when you're already on the main thread or in a blocking context.
-/// For async code with spawn_blocking, use download_image_bytes + bytes_to_slint_image separately.
-pub fn download_and_convert_image(url: &str) -> Option<Image> {
-    download_image_bytes(url).and_then(bytes_to_slint_image)
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,0 +1,76 @@
+// Utility functions for image processing and date parsing
+//
+// This module provides helper functions for:
+// - Downloading images from URLs
+// - Converting image bytes to Slint Image format
+// - Parsing Sveriges Radio's date format
+
+use chrono::{DateTime, Utc};
+use chrono_tz::Europe::Stockholm;
+use slint::Image;
+
+pub fn parse_sr_date_to_time(date_str: &str) -> String {
+    if let Some(ms_str) = date_str
+        .strip_prefix("/Date(")
+        .and_then(|s| s.strip_suffix(")/"))
+    {
+        if let Ok(ms) = ms_str.parse::<i64>() {
+            return DateTime::from_timestamp_millis(ms)
+                .map(|dt: DateTime<Utc>| {
+                    let stockholm_time = dt.with_timezone(&Stockholm);
+                    stockholm_time.format("%H:%M").to_string()
+                })
+                .unwrap_or_else(|| String::from("--:--"));
+        }
+    }
+    String::from("--:--")
+}
+
+
+/// Download image bytes from a URL
+///
+/// Returns raw bytes which are Send-safe for use across threads.
+/// Call this in spawn_blocking, then use bytes_to_slint_image on the main thread.
+pub fn download_image_bytes(url: &str) -> Option<Vec<u8>> {
+    if url.is_empty() {
+        return None;
+    }
+
+    match reqwest::blocking::get(url) {
+        Ok(response) => response.bytes().ok().map(|b| b.to_vec()),
+        Err(e) => {
+            eprintln!("Failed to download image from {}: {}", url, e);
+            None
+        }
+    }
+}
+
+/// Convert raw image bytes to Slint Image format
+///
+/// MUST be called on the main thread (Slint Image is not Send).
+pub fn bytes_to_slint_image(bytes: Vec<u8>) -> Option<Image> {
+    match image::load_from_memory(&bytes) {
+        Ok(img) => {
+            let rgba = img.to_rgba8();
+            let (width, height) = rgba.dimensions();
+            let buffer = slint::SharedPixelBuffer::clone_from_slice(
+                &rgba.into_raw(),
+                width,
+                height,
+            );
+            Some(Image::from_rgba8(buffer))
+        }
+        Err(e) => {
+            eprintln!("Failed to decode image: {}", e);
+            None
+        }
+    }
+}
+
+/// Download and convert image in one call (convenience function)
+///
+/// Use this when you're already on the main thread or in a blocking context.
+/// For async code with spawn_blocking, use download_image_bytes + bytes_to_slint_image separately.
+pub fn download_and_convert_image(url: &str) -> Option<Image> {
+    download_image_bytes(url).and_then(bytes_to_slint_image)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,44 @@ fn empty_program_info() -> ProgramInfo {
         description: "".into(),
         start_time: "".into(),
         end_time: "".into(),
+        show_image: slint::Image::default(),
+    }
+}
+
+/// Download image bytes from URL
+fn download_image_bytes(url: &str) -> Option<Vec<u8>> {
+    if url.is_empty() {
+        return None;
+    }
+
+    match reqwest::blocking::get(url) {
+        Ok(response) => {
+            response.bytes().ok().map(|b| b.to_vec())
+        }
+        Err(e) => {
+            eprintln!("Failed to download image from {}: {}", url, e);
+            None
+        }
+    }
+}
+
+/// Convert image bytes to Slint Image using the image crate
+fn bytes_to_slint_image(bytes: Vec<u8>) -> Option<slint::Image> {
+    match image::load_from_memory(&bytes) {
+        Ok(img) => {
+            let rgba = img.to_rgba8();
+            let (width, height) = (rgba.width(), rgba.height());
+            let buffer = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::clone_from_slice(
+                rgba.as_raw(),
+                width,
+                height,
+            );
+            Some(slint::Image::from_rgba8(buffer))
+        }
+        Err(e) => {
+            eprintln!("Failed to decode image: {}", e);
+            None
+        }
     }
 }
 
@@ -227,17 +265,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 // Update UI with program information
                 if let Some(episode) = program_info {
+                    // Download image bytes in blocking task
+                    let image_url = episode.social_image.clone().unwrap_or_default();
+                    let image_bytes = tokio::task::spawn_blocking(move || {
+                        download_image_bytes(&image_url)
+                    })
+                    .await
+                    .ok()
+                    .flatten();
+
                     ui_clone
                         .upgrade_in_event_loop(move |ui| {
                             // Format times (convert from /Date(ms)/ format to HH:MM)
                             let start_time = parse_sr_date_to_time(&episode.start_time_utc);
                             let end_time = parse_sr_date_to_time(&episode.end_time_utc);
 
+                            // Convert image bytes to Slint Image on the main thread
+                            let show_image = image_bytes
+                                .and_then(bytes_to_slint_image)
+                                .unwrap_or_default();
+
                             ui.set_current_program(ProgramInfo {
                                 title: episode.title.clone().into(),
                                 description: episode.description.unwrap_or_default().into(),
                                 start_time: start_time.into(),
                                 end_time: end_time.into(),
+                                show_image,
                             });
                         })
                         .ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,27 @@
-// SR Player - Main entry point
+// SR Player - Sveriges Radio Streaming Application
 //
-// This is where the program starts (like if __name__ == "__main__" in Python)
+// A native desktop application for streaming Sveriges Radio channels and podcasts.
+// Features:
+// - Live radio streaming with gapless playback (no gaps between tracks)
+// - Browse and play podcast episodes (25 most recent per program)
+// - Organized tabs: Live channels, Podcasts, News, Music
+// - Automatic program info updates (polls every 30 seconds)
+// - Stockholm timezone support (handles CET/CEST automatically)
+//
+// ARCHITECTURE:
+// - UI: Slint (declarative UI framework)
+// - Audio: Rodio + Symphonia (gapless AAC/MP3 streaming)
+// - Network: Reqwest (blocking HTTP client)
+// - Async: Tokio runtime (for concurrent operations)
 //
 // PROGRAM FLOW:
-// 1. Initialize logging (for debugging)
-// 2. Load Slint UI
+// 1. Initialize Tokio runtime and logging
+// 2. Load Slint UI components
 // 3. Create API client and audio player
 // 4. Fetch channels from SR API
 // 5. Set up UI callbacks (event handlers)
-// 6. Show window and run event loop
+// 6. Start periodic program update task
+// 7. Show window and run event loop
 
 // MODULE DECLARATIONS
 // Like 'import' in Python or JavaScript
@@ -20,9 +33,10 @@ mod core; // This loads src/core/mod.rs
 // Or: import { SrApiClient } from './core/api' in JavaScript
 use core::api::SrApiClient;
 use core::gapless_send_safe::SendSafeGaplessPlayer; // M3: Send-safe gapless streaming!
+use core::utils::{bytes_to_slint_image, download_image_bytes, parse_sr_date_to_time};
 
 // Import Slint types
-use slint::{ModelRc, VecModel};
+use slint::{Model, ModelRc, VecModel};
 
 // Standard library imports
 // Arc = Atomic Reference Counted (thread-safe reference counting)
@@ -39,24 +53,6 @@ slint::include_modules!();
 // HELPER FUNCTIONS
 // ============================================================================
 
-/// Parse SR API date format /Date(milliseconds)/ and convert to HH:MM format
-/// Example: "/Date(1762431000000)/" -> "10:30"
-fn parse_sr_date_to_time(date_str: &str) -> String {
-    use chrono::{DateTime, Utc};
-
-    if let Some(ms_str) = date_str
-        .strip_prefix("/Date(")
-        .and_then(|s| s.strip_suffix(")/"))
-    {
-        if let Ok(ms) = ms_str.parse::<i64>() {
-            return DateTime::from_timestamp_millis(ms)
-                .map(|dt: DateTime<Utc>| dt.format("%H:%M").to_string())
-                .unwrap_or_else(|| String::from("--:--"));
-        }
-    }
-    String::from("--:--")
-}
-
 /// Create an empty ProgramInfo struct (helper to avoid duplication)
 fn empty_program_info() -> ProgramInfo {
     ProgramInfo {
@@ -65,43 +61,79 @@ fn empty_program_info() -> ProgramInfo {
         start_time: "".into(),
         end_time: "".into(),
         show_image: slint::Image::default(),
+        program_id: 0,
+        has_podcasts: false,
     }
 }
 
-/// Download image bytes from URL
-fn download_image_bytes(url: &str) -> Option<Vec<u8>> {
-    if url.is_empty() {
-        return None;
-    }
+/// Fetch and update program information for a given channel ID
+/// Returns the current program title to detect changes
+async fn update_program_info(
+    ui_weak: &slint::Weak<MainWindow>,
+    api_client: &SrApiClient,
+    channel_id: i32,
+) -> Option<String> {
+    // Fetch current program information in a blocking task
+    let api_clone = api_client.clone();
+    let program_info = tokio::task::spawn_blocking(move || {
+        match api_clone.get_schedule_right_now() {
+            Ok(schedule) => {
+                schedule
+                    .channels
+                    .iter()
+                    .find(|ch| ch.id == channel_id as u32)
+                    .and_then(|ch| ch.current_episode.clone())
+            }
+            Err(e) => {
+                eprintln!("Failed to fetch schedule: {}", e);
+                None
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten();
 
-    match reqwest::blocking::get(url) {
-        Ok(response) => {
-            response.bytes().ok().map(|b| b.to_vec())
-        }
-        Err(e) => {
-            eprintln!("Failed to download image from {}: {}", url, e);
-            None
-        }
-    }
-}
+    // Update UI with program information
+    if let Some(episode) = program_info {
+        let program_title = episode.title.clone();
 
-/// Convert image bytes to Slint Image using the image crate
-fn bytes_to_slint_image(bytes: Vec<u8>) -> Option<slint::Image> {
-    match image::load_from_memory(&bytes) {
-        Ok(img) => {
-            let rgba = img.to_rgba8();
-            let (width, height) = (rgba.width(), rgba.height());
-            let buffer = slint::SharedPixelBuffer::<slint::Rgba8Pixel>::clone_from_slice(
-                rgba.as_raw(),
-                width,
-                height,
-            );
-            Some(slint::Image::from_rgba8(buffer))
-        }
-        Err(e) => {
-            eprintln!("Failed to decode image: {}", e);
-            None
-        }
+        // Download image bytes in blocking task
+        let image_url = episode.social_image.clone().unwrap_or_default();
+        let image_bytes = tokio::task::spawn_blocking(move || download_image_bytes(&image_url))
+            .await
+            .ok()
+            .flatten();
+
+        ui_weak
+            .upgrade_in_event_loop(move |ui| {
+                // Format times (convert from /Date(ms)/ format to HH:MM)
+                let start_time = parse_sr_date_to_time(&episode.start_time_utc);
+                let end_time = parse_sr_date_to_time(&episode.end_time_utc);
+
+                // Convert bytes to Slint Image on main thread (Image is not Send)
+                let show_image = image_bytes
+                    .and_then(bytes_to_slint_image)
+                    .unwrap_or_default();
+
+                // Get program ID
+                let program_id = episode.program.as_ref().map(|p| p.id).unwrap_or(0);
+
+                ui.set_current_program(ProgramInfo {
+                    title: episode.title.clone().into(),
+                    description: episode.description.unwrap_or_default().into(),
+                    start_time: start_time.into(),
+                    end_time: end_time.into(),
+                    show_image,
+                    program_id: program_id as i32,
+                    has_podcasts: false,
+                });
+            })
+            .ok();
+
+        Some(program_title)
+    } else {
+        None
     }
 }
 
@@ -201,6 +233,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Channels loaded into UI");
 
     // ========================================================================
+    // SHARED STATE FOR GROUP MANAGEMENT AND INFINITE SCROLLING
+    // ========================================================================
+
+    // Track which program groups are expanded/collapsed
+    let groups_expanded = Arc::new(std::sync::Mutex::new(HashMap::<i32, bool>::new()));
+
+    // Cache all programs for infinite scrolling
+    let all_programs = Arc::new(std::sync::Mutex::new(Vec::<core::models::Program>::new()));
+
+    // Track the currently playing channel ID for periodic program updates
+    let current_channel_id = Arc::new(std::sync::Mutex::new(Option::<i32>::None));
+
+    // ========================================================================
     // STEP 4: SET UP UI CALLBACKS (EVENT HANDLERS)
     // ========================================================================
 
@@ -219,9 +264,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let runtime_handle = runtime.handle().clone();
         let api_client_clone = api_client.clone();
         let channel_map_clone = channel_map.clone();
+        let current_channel_id_clone = current_channel_id.clone();
 
         ui.on_channel_selected(move |channel_id, stream_url| {
             println!("Channel selected: ID={}, URL={}", channel_id, stream_url);
+
+            // Store the current channel ID for periodic program updates
+            if let Ok(mut current_id) = current_channel_id_clone.lock() {
+                *current_id = Some(channel_id);
+            }
 
             let ui = ui_weak.upgrade().unwrap();
             ui.set_is_loading(true);
@@ -280,10 +331,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let start_time = parse_sr_date_to_time(&episode.start_time_utc);
                             let end_time = parse_sr_date_to_time(&episode.end_time_utc);
 
-                            // Convert image bytes to Slint Image on the main thread
+                            // Convert bytes to Slint Image on main thread (Image is not Send)
                             let show_image = image_bytes
                                 .and_then(bytes_to_slint_image)
                                 .unwrap_or_default();
+
+                            // Get program ID and check if it has podcasts
+                            let program_id = episode.program.as_ref().map(|p| p.id).unwrap_or(0);
 
                             ui.set_current_program(ProgramInfo {
                                 title: episode.title.clone().into(),
@@ -291,6 +345,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 start_time: start_time.into(),
                                 end_time: end_time.into(),
                                 show_image,
+                                program_id: program_id as i32,
+                                has_podcasts: false, // We'll check this later if needed
                             });
                         })
                         .ok();
@@ -325,9 +381,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let ui_weak = ui.as_weak();
         let player = streaming_player.clone();
         let runtime_handle = runtime.handle().clone();
+        let current_channel_id_clone = current_channel_id.clone();
 
         ui.on_stop_clicked(move || {
             println!("Stopping playback");
+
+            // Clear the current channel ID to stop periodic program updates
+            if let Ok(mut current_id) = current_channel_id_clone.lock() {
+                *current_id = None;
+            }
 
             let ui_clone = ui_weak.clone();
             let player_clone = player.clone();
@@ -346,7 +408,419 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
+    // CALLBACK 3: Podcasts tab clicked - lazy load programs with grouping
+    {
+        let ui_weak = ui.as_weak();
+        let runtime_handle = runtime.handle().clone();
+        let api_client_clone = api_client.clone();
+        let all_programs_clone = all_programs.clone();
+
+        ui.on_podcasts_tab_clicked(move || {
+            let ui = ui_weak.upgrade().unwrap();
+
+            // Check if we have data already loaded
+            let programs_available = {
+                let all_programs_lock = all_programs_clone.lock().unwrap();
+                !all_programs_lock.is_empty()
+            };
+
+            if programs_available {
+                // Filter existing data for Podcasts tab
+                let all_programs_lock = all_programs_clone.lock().unwrap();
+                let program_items = core::podcast::programs_to_items_podcasts(&all_programs_lock);
+                let programs_model = Rc::new(VecModel::from(program_items));
+                ui.set_programs(ModelRc::from(programs_model));
+            } else {
+                // First time loading - fetch data
+                println!("Loading programs with podcasts...");
+
+                let ui_clone = ui_weak.clone();
+                let api_clone = api_client_clone.clone();
+                let all_programs_clone2 = all_programs_clone.clone();
+
+                runtime_handle.spawn(async move {
+                    match core::podcast::fetch_programs_with_podcasts(&api_clone).await {
+                        Ok(programs) => {
+                            // Store programs for future use by all tabs
+                            {
+                                let mut all_programs_lock = all_programs_clone2.lock().unwrap();
+                                *all_programs_lock = programs.clone();
+                            }
+
+                            // Show filtered data for Podcasts tab
+                            if let Err(e) = ui_clone.upgrade_in_event_loop(move |ui| {
+                                let program_items = core::podcast::programs_to_items_podcasts(&programs);
+                                let programs_model = Rc::new(VecModel::from(program_items));
+                                ui.set_programs(ModelRc::from(programs_model));
+                                ui.set_programs_loaded(true);
+                            }) {
+                                eprintln!("Failed to update UI with programs: {:?}", e);
+                            }
+                        }
+                        Err(e) => eprintln!("Failed to fetch programs: {}", e),
+                    }
+                });
+            }
+        });
+
+        // News tab callback - reuse the same logic as podcasts but for news filtering
+        let ui_weak_news = ui.as_weak();
+        let api_client_clone_news = api_client.clone();
+        let groups_expanded_clone_news = groups_expanded.clone();
+        let all_programs_clone_news = all_programs.clone();
+        let runtime_handle_news = runtime.handle().clone();
+
+        ui.on_news_tab_clicked(move || {
+            let ui = ui_weak_news.upgrade().unwrap();
+
+            // Check if we have data already loaded
+            let programs_available = {
+                let all_programs_lock = all_programs_clone_news.lock().unwrap();
+                !all_programs_lock.is_empty()
+            };
+
+            if programs_available {
+                // Filter existing data for News tab
+                let all_programs_lock = all_programs_clone_news.lock().unwrap();
+                let groups_expanded_lock = groups_expanded_clone_news.lock().unwrap();
+                let program_items = core::podcast::programs_to_items_news(&all_programs_lock, &groups_expanded_lock);
+                let programs_model = Rc::new(VecModel::from(program_items));
+                ui.set_news_programs(ModelRc::from(programs_model));
+            } else {
+                // First time loading - fetch data
+                println!("Loading programs for news tab...");
+
+                let ui_clone = ui_weak_news.clone();
+                let api_clone = api_client_clone_news.clone();
+                let groups_expanded_clone2 = groups_expanded_clone_news.clone();
+                let all_programs_clone2 = all_programs_clone_news.clone();
+
+                runtime_handle_news.spawn(async move {
+                    match core::podcast::fetch_programs_with_podcasts(&api_clone).await {
+                        Ok(programs) => {
+                            // Store programs for future use by all tabs
+                            {
+                                let mut all_programs_lock = all_programs_clone2.lock().unwrap();
+                                *all_programs_lock = programs.clone();
+                            }
+
+                            // Show filtered data for News tab
+                            if let Err(e) = ui_clone.upgrade_in_event_loop(move |ui| {
+                                let groups_expanded_lock = groups_expanded_clone2.lock().unwrap();
+                                let program_items = core::podcast::programs_to_items_news(&programs, &groups_expanded_lock);
+                                let programs_model = Rc::new(VecModel::from(program_items));
+                                ui.set_news_programs(ModelRc::from(programs_model));
+                                ui.set_news_loaded(true);
+                            }) {
+                                eprintln!("Failed to update UI with programs: {:?}", e);
+                            }
+                        }
+                        Err(e) => eprintln!("Failed to fetch programs: {}", e),
+                    }
+                });
+            }
+        });
+    }
+
+    // CALLBACK 4: Browse podcasts button (M4)
+    {
+        let ui_weak = ui.as_weak();
+        let runtime_handle = runtime.handle().clone();
+        let api_client_clone = api_client.clone();
+
+        ui.on_browse_podcasts_clicked(move |program_id| {
+            println!("Browse podcasts clicked for program ID: {}", program_id);
+
+            let ui_clone = ui_weak.clone();
+            let api_clone = api_client_clone.clone();
+
+            runtime_handle.spawn(async move {
+                match core::podcast::fetch_episodes_for_program(&api_clone, program_id as u32).await {
+                    Ok((episode_items, program_name)) => {
+                        if let Err(e) = ui_clone.upgrade_in_event_loop(move |ui| {
+                            let episodes_model = Rc::new(VecModel::from(episode_items));
+                            ui.set_episodes(ModelRc::from(episodes_model));
+                            ui.set_selected_program_name(program_name.into());
+                            ui.set_current_tab(1); // Switch to podcasts tab
+                            ui.set_show_episodes_view(true);
+                        }) {
+                            eprintln!("Failed to update UI with episodes: {:?}", e);
+                        }
+                    }
+                    Err(e) => eprintln!("Failed to fetch episodes: {}", e),
+                }
+            });
+        });
+    }
+
+    // CALLBACK 5: Program selected in podcasts tab (M4)
+    // Fetches and displays episodes for the selected program
+    {
+        let ui_weak = ui.as_weak();
+        let runtime_handle = runtime.handle().clone();
+        let api_client_clone = api_client.clone();
+
+        ui.on_program_selected(move |program_id| {
+            println!("Program selected: ID={}", program_id);
+
+            let ui_clone = ui_weak.clone();
+            let api_clone = api_client_clone.clone();
+
+            runtime_handle.spawn(async move {
+                match core::podcast::fetch_episodes_for_program(&api_clone, program_id as u32).await {
+                    Ok((episode_items, program_name)) => {
+                        if let Err(e) = ui_clone.upgrade_in_event_loop(move |ui| {
+                            let episodes_model = Rc::new(VecModel::from(episode_items));
+                            ui.set_episodes(ModelRc::from(episodes_model));
+                            ui.set_selected_program_name(program_name.into());
+                            ui.set_selected_program_id(program_id);
+                            ui.set_show_episodes_view(true);
+                        }) {
+                            eprintln!("Failed to update UI with episodes: {:?}", e);
+                        }
+                    }
+                    Err(e) => eprintln!("Failed to fetch episodes: {}", e),
+                }
+            });
+        });
+    }
+
+    // CALLBACK 6: Episode selected for playback (M4)
+    {
+        let ui_weak = ui.as_weak();
+        let player = streaming_player.clone();
+        let runtime_handle = runtime.handle().clone();
+        let all_programs_clone = all_programs.clone();
+        let current_channel_id_clone = current_channel_id.clone();
+
+        ui.on_episode_selected(move |episode_id| {
+            println!("Episode selected: ID={}", episode_id);
+
+            // Clear the current channel ID to stop live program polling
+            if let Ok(mut current_id) = current_channel_id_clone.lock() {
+                *current_id = None;
+            }
+
+            let ui = ui_weak.upgrade().unwrap();
+            ui.set_is_loading(true);
+            ui.set_current_channel_name("Podcast".into());
+
+            // Find the selected episode in the episodes list
+            let episodes = ui.get_episodes();
+            let mut selected_episode: Option<EpisodeItem> = None;
+            for i in 0..episodes.row_count() {
+                if let Some(episode) = episodes.row_data(i) {
+                    if episode.id == episode_id {
+                        selected_episode = Some(episode);
+                        break;
+                    }
+                }
+            }
+
+            if let Some(episode) = selected_episode {
+                // Find the program image from cached programs using the selected program ID
+                let current_program_id = ui.get_selected_program_id();
+                let program_image_url = {
+                    let all_programs_lock = all_programs_clone.lock().unwrap();
+                    all_programs_lock
+                        .iter()
+                        .find(|p| p.id as i32 == current_program_id)
+                        .and_then(|p| p.program_image.clone().or(p.social_image.clone()))
+                };
+
+                // Set episode information in the top UI (initially without image)
+                ui.set_current_program(ProgramInfo {
+                    title: episode.title.clone(),
+                    description: episode.description.clone(),
+                    start_time: "".into(), // Not applicable for podcasts
+                    end_time: episode.publish_date.clone(), // Show publish date instead
+                    show_image: slint::Image::default(), // Will be updated below if image is available
+                    program_id: 0, // Not applicable for episodes
+                    has_podcasts: false,
+                });
+
+                let episode_url = episode.url.to_string();
+                let ui_clone = ui_weak.clone();
+                let player_clone = player.clone();
+
+                // Load program image in background if available
+                if let Some(image_url) = program_image_url {
+                    let ui_clone_for_image = ui_weak.clone();
+                    let episode_title = episode.title.clone();
+                    let episode_description = episode.description.clone();
+                    let episode_date = episode.publish_date.clone();
+
+                    runtime_handle.spawn(async move {
+                        // Download image bytes in blocking task
+                        let image_bytes = tokio::task::spawn_blocking(move || {
+                            download_image_bytes(&image_url)
+                        })
+                        .await
+                        .ok()
+                        .flatten();
+
+                        // Update UI with image on main thread
+                        let _ = ui_clone_for_image.upgrade_in_event_loop(move |ui| {
+                            // Convert bytes to Slint Image on main thread (Image is not Send)
+                            let show_image = image_bytes
+                                .and_then(bytes_to_slint_image)
+                                .unwrap_or_default();
+
+                            ui.set_current_program(ProgramInfo {
+                                title: episode_title,
+                                description: episode_description,
+                                start_time: "".into(),
+                                end_time: episode_date,
+                                show_image,
+                                program_id: 0,
+                                has_podcasts: false,
+                            });
+                        });
+                    });
+                }
+
+                runtime_handle.spawn(async move {
+                    match player_clone.start_stream(episode_url).await {
+                        Ok(_) => {
+                            println!("Podcast playback started");
+                            if let Err(e) = ui_clone.upgrade_in_event_loop(|ui| {
+                                ui.set_is_playing(true);
+                                ui.set_is_loading(false);
+                            }) {
+                                eprintln!("Failed to update UI after podcast start: {:?}", e);
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to start podcast: {}", e);
+                            if let Err(e) = ui_clone.upgrade_in_event_loop(|ui| {
+                                ui.set_is_playing(false);
+                                ui.set_is_loading(false);
+                            }) {
+                                eprintln!("Failed to update UI after podcast error: {:?}", e);
+                            }
+                        }
+                    }
+                });
+            } else {
+                eprintln!("Episode with ID {} not found", episode_id);
+                let ui_clone = ui_weak.clone();
+                if let Err(e) = ui_clone.upgrade_in_event_loop(|ui| {
+                    ui.set_is_loading(false);
+                }) {
+                    eprintln!("Failed to update UI after episode not found: {:?}", e);
+                }
+            }
+        });
+    }
+
+    // CALLBACK 7: Back to programs list (M4)
+    {
+        let ui_weak = ui.as_weak();
+
+        ui.on_back_to_programs_clicked(move || {
+            println!("Back to programs clicked");
+
+            if let Some(ui) = ui_weak.upgrade() {
+                ui.set_show_episodes_view(false);
+            }
+        });
+    }
+
+    // CALLBACK 8: Group toggled (expand/collapse P4 group)
+    {
+        let ui_weak = ui.as_weak();
+        let groups_expanded_clone = groups_expanded.clone();
+        let all_programs_clone = all_programs.clone();
+
+        ui.on_group_toggled(move |group_id| {
+            println!("Group toggled: ID={}", group_id);
+
+            let ui = ui_weak.upgrade().unwrap();
+
+            // Toggle group expansion state
+            {
+                let mut groups_expanded_lock = groups_expanded_clone.lock().unwrap();
+                let current_state = groups_expanded_lock.get(&group_id).copied().unwrap_or(false);
+                groups_expanded_lock.insert(group_id, !current_state);
+            }
+
+            // Refresh program list to show/hide children based on current tab
+            {
+                let all_programs_lock = all_programs_clone.lock().unwrap();
+                let groups_expanded_lock = groups_expanded_clone.lock().unwrap();
+                let current_tab = ui.get_current_tab();
+
+                if current_tab == 2 {
+                    // News tab - show only news programs
+                    let program_items = core::podcast::programs_to_items_news(&all_programs_lock, &groups_expanded_lock);
+                    let programs_model = Rc::new(VecModel::from(program_items));
+                    ui.set_news_programs(ModelRc::from(programs_model));
+                } else if current_tab == 1 {
+                    // Podcasts tab - exclude news programs
+                    let program_items = core::podcast::programs_to_items_podcasts(&all_programs_lock);
+                    let programs_model = Rc::new(VecModel::from(program_items));
+                    ui.set_programs(ModelRc::from(programs_model));
+                }
+            }
+        });
+    }
+
+    // CALLBACK 9: Load more programs (placeholder for future infinite scrolling)
+    {
+        let _ui_weak = ui.as_weak();
+
+        ui.on_load_more_programs(move || {
+            println!("Load more programs requested");
+            // Future enhancement: implement infinite scrolling here
+            // For now, all programs are loaded at once with grouping
+        });
+    }
+
     println!("UI callbacks configured");
+
+    // ========================================================================
+    // PERIODIC PROGRAM UPDATE TASK
+    // ========================================================================
+
+    // Spawn a background task to periodically check for program changes
+    // This runs every 30 seconds and updates the UI when a new show starts
+    {
+        let ui_weak = ui.as_weak();
+        let api_client_clone = api_client.clone();
+        let current_channel_id_clone = current_channel_id.clone();
+        let runtime_handle = runtime.handle().clone();
+
+        runtime_handle.spawn(async move {
+            let mut last_program_title: Option<String> = None;
+
+            loop {
+                // Wait 30 seconds between checks
+                tokio::time::sleep(tokio::time::Duration::from_secs(30)).await;
+
+                // Check if a channel is currently playing
+                let channel_id = {
+                    let current_id = current_channel_id_clone.lock().unwrap();
+                    *current_id
+                };
+
+                if let Some(id) = channel_id {
+                    // Fetch and update program information
+                    if let Some(new_title) = update_program_info(&ui_weak, &api_client_clone, id).await {
+                        // Check if the program has changed
+                        if last_program_title.as_ref() != Some(&new_title) {
+                            println!("Program changed to: {}", new_title);
+                            last_program_title = Some(new_title);
+                        }
+                    }
+                } else {
+                    // No channel playing, reset last program title
+                    last_program_title = None;
+                }
+            }
+        });
+    }
+
+    println!("Periodic program update task started");
 
     // ========================================================================
     // STEP 5: RUN THE APPLICATION

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,24 +75,21 @@ async fn update_program_info(
 ) -> Option<String> {
     // Fetch current program information in a blocking task
     let api_clone = api_client.clone();
-    let program_info = tokio::task::spawn_blocking(move || {
-        match api_clone.get_schedule_right_now() {
-            Ok(schedule) => {
-                schedule
-                    .channels
-                    .iter()
-                    .find(|ch| ch.id == channel_id as u32)
-                    .and_then(|ch| ch.current_episode.clone())
-            }
+    let program_info =
+        tokio::task::spawn_blocking(move || match api_clone.get_schedule_right_now() {
+            Ok(schedule) => schedule
+                .channels
+                .iter()
+                .find(|ch| ch.id == channel_id as u32)
+                .and_then(|ch| ch.current_episode.clone()),
             Err(e) => {
                 eprintln!("Failed to fetch schedule: {}", e);
                 None
             }
-        }
-    })
-    .await
-    .ok()
-    .flatten();
+        })
+        .await
+        .ok()
+        .flatten();
 
     // Update UI with program information
     if let Some(episode) = program_info {
@@ -318,12 +315,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(episode) = program_info {
                     // Download image bytes in blocking task
                     let image_url = episode.social_image.clone().unwrap_or_default();
-                    let image_bytes = tokio::task::spawn_blocking(move || {
-                        download_image_bytes(&image_url)
-                    })
-                    .await
-                    .ok()
-                    .flatten();
+                    let image_bytes =
+                        tokio::task::spawn_blocking(move || download_image_bytes(&image_url))
+                            .await
+                            .ok()
+                            .flatten();
 
                     ui_clone
                         .upgrade_in_event_loop(move |ui| {
@@ -449,7 +445,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                             // Show filtered data for Podcasts tab
                             if let Err(e) = ui_clone.upgrade_in_event_loop(move |ui| {
-                                let program_items = core::podcast::programs_to_items_podcasts(&programs);
+                                let program_items =
+                                    core::podcast::programs_to_items_podcasts(&programs);
                                 let programs_model = Rc::new(VecModel::from(program_items));
                                 ui.set_programs(ModelRc::from(programs_model));
                                 ui.set_programs_loaded(true);
@@ -483,7 +480,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // Filter existing data for News tab
                 let all_programs_lock = all_programs_clone_news.lock().unwrap();
                 let groups_expanded_lock = groups_expanded_clone_news.lock().unwrap();
-                let program_items = core::podcast::programs_to_items_news(&all_programs_lock, &groups_expanded_lock);
+                let program_items = core::podcast::programs_to_items_news(
+                    &all_programs_lock,
+                    &groups_expanded_lock,
+                );
                 let programs_model = Rc::new(VecModel::from(program_items));
                 ui.set_news_programs(ModelRc::from(programs_model));
             } else {
@@ -507,7 +507,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             // Show filtered data for News tab
                             if let Err(e) = ui_clone.upgrade_in_event_loop(move |ui| {
                                 let groups_expanded_lock = groups_expanded_clone2.lock().unwrap();
-                                let program_items = core::podcast::programs_to_items_news(&programs, &groups_expanded_lock);
+                                let program_items = core::podcast::programs_to_items_news(
+                                    &programs,
+                                    &groups_expanded_lock,
+                                );
                                 let programs_model = Rc::new(VecModel::from(program_items));
                                 ui.set_news_programs(ModelRc::from(programs_model));
                                 ui.set_news_loaded(true);
@@ -535,7 +538,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let api_clone = api_client_clone.clone();
 
             runtime_handle.spawn(async move {
-                match core::podcast::fetch_episodes_for_program(&api_clone, program_id as u32).await {
+                match core::podcast::fetch_episodes_for_program(&api_clone, program_id as u32).await
+                {
                     Ok((episode_items, program_name)) => {
                         if let Err(e) = ui_clone.upgrade_in_event_loop(move |ui| {
                             let episodes_model = Rc::new(VecModel::from(episode_items));
@@ -567,7 +571,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let api_clone = api_client_clone.clone();
 
             runtime_handle.spawn(async move {
-                match core::podcast::fetch_episodes_for_program(&api_clone, program_id as u32).await {
+                match core::podcast::fetch_episodes_for_program(&api_clone, program_id as u32).await
+                {
                     Ok((episode_items, program_name)) => {
                         if let Err(e) = ui_clone.upgrade_in_event_loop(move |ui| {
                             let episodes_model = Rc::new(VecModel::from(episode_items));
@@ -635,7 +640,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     start_time: "".into(), // Not applicable for podcasts
                     end_time: episode.publish_date.clone(), // Show publish date instead
                     show_image: slint::Image::default(), // Will be updated below if image is available
-                    program_id: 0, // Not applicable for episodes
+                    program_id: 0,                       // Not applicable for episodes
                     has_podcasts: false,
                 });
 
@@ -652,12 +657,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                     runtime_handle.spawn(async move {
                         // Download image bytes in blocking task
-                        let image_bytes = tokio::task::spawn_blocking(move || {
-                            download_image_bytes(&image_url)
-                        })
-                        .await
-                        .ok()
-                        .flatten();
+                        let image_bytes =
+                            tokio::task::spawn_blocking(move || download_image_bytes(&image_url))
+                                .await
+                                .ok()
+                                .flatten();
 
                         // Update UI with image on main thread
                         let _ = ui_clone_for_image.upgrade_in_event_loop(move |ui| {
@@ -740,7 +744,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Toggle group expansion state
             {
                 let mut groups_expanded_lock = groups_expanded_clone.lock().unwrap();
-                let current_state = groups_expanded_lock.get(&group_id).copied().unwrap_or(false);
+                let current_state = groups_expanded_lock
+                    .get(&group_id)
+                    .copied()
+                    .unwrap_or(false);
                 groups_expanded_lock.insert(group_id, !current_state);
             }
 
@@ -752,12 +759,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 if current_tab == 2 {
                     // News tab - show only news programs
-                    let program_items = core::podcast::programs_to_items_news(&all_programs_lock, &groups_expanded_lock);
+                    let program_items = core::podcast::programs_to_items_news(
+                        &all_programs_lock,
+                        &groups_expanded_lock,
+                    );
                     let programs_model = Rc::new(VecModel::from(program_items));
                     ui.set_news_programs(ModelRc::from(programs_model));
                 } else if current_tab == 1 {
                     // Podcasts tab - exclude news programs
-                    let program_items = core::podcast::programs_to_items_podcasts(&all_programs_lock);
+                    let program_items =
+                        core::podcast::programs_to_items_podcasts(&all_programs_lock);
                     let programs_model = Rc::new(VecModel::from(program_items));
                     ui.set_programs(ModelRc::from(programs_model));
                 }
@@ -805,7 +816,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 if let Some(id) = channel_id {
                     // Fetch and update program information
-                    if let Some(new_title) = update_program_info(&ui_weak, &api_client_clone, id).await {
+                    if let Some(new_title) =
+                        update_program_info(&ui_weak, &api_client_clone, id).await
+                    {
                         // Check if the program has changed
                         if last_program_title.as_ref() != Some(&new_title) {
                             println!("Program changed to: {}", new_title);

--- a/src/ui/main.slint
+++ b/src/ui/main.slint
@@ -1,5 +1,10 @@
 // Slint UI definition for SR Player
 //
+// This is the main application window that brings together all UI components:
+// - NowPlaying: Shows current channel and program information
+// - TabContent: Reusable component for Live, Podcasts, News, Music tabs
+// - Tab navigation and content switching
+//
 // SLINT is a declarative UI framework (like HTML/CSS or SwiftUI)
 //
 // Compare to:
@@ -16,44 +21,34 @@
 // Like: import { Button } from 'react' or from tkinter import Button
 import { Button, VerticalBox, HorizontalBox, ListView, ScrollView } from "std-widgets.slint";
 
-// Define a struct to represent a channel in the UI
-// This is like a TypeScript interface or Python dataclass:
-//
-// Python equivalent:
-//   @dataclass
-//   class ChannelItem:
-//       id: int
-//       name: str
-//       stream_url: str
-//
-// TypeScript equivalent:
-//   interface ChannelItem {
-//       id: number;
-//       name: string;
-//       stream_url: string;
-//   }
-export struct ChannelItem {
-    id: int,           // Channel ID (like 132 for SR P1)
-    name: string,      // Channel name (like "SR P1")
-    stream-url: string, // URL to the MP3 stream
-}
 
-// Struct to represent currently playing program information
-export struct ProgramInfo {
-    title: string,           // Current program title
-    description: string,     // Program description
-    start-time: string,      // Start time (formatted)
-    end-time: string,        // End time (formatted)
-    show-image: image,       // Show image (loaded from URL)
-}
+import { ChannelItem, ProgramInfo, ProgramItem, EpisodeItem } from "types.slint";
+
+import { NowPlaying } from "now_playing.slint";
+import { TabContent } from "tab_content.slint";
+import { TabBar, TabItem } from "tab_bar.slint";
+
+// Re-export types so they're available to Rust code
+export { ChannelItem, ProgramInfo, ProgramItem, EpisodeItem }
 
 // Main application window component
 // Like <App> component in React or main() window in Tkinter
 export component MainWindow inherits Window {
-    // PROPERTIES (like React state or instance variables)
-    // These can be accessed and modified from Rust code
+    // ================================================================
+    // WINDOW PROPERTIES
+    // ================================================================
+    title: "SR Player - Sveriges Radio";
+    min-width: 300px;
+    min-height: 300px;
+    preferred-width: 360px;
+    preferred-height: 600px;
+    background: #1a1a1a;
 
-    // in-out means the property can be read and written from outside
+    // ================================================================
+    // APPLICATION STATE
+    // ================================================================
+
+    // Current playback state
     in-out property <string> current-channel-name: "No channel selected";
     in-out property <bool> is-playing: false;
     in-out property <bool> is-loading: false;
@@ -62,128 +57,75 @@ export component MainWindow inherits Window {
         description: "",
         start-time: "",
         end-time: "",
-        show-image: @image-url("")
+        show-image: @image-url(""),
+        program-id: 0,
+        has-podcasts: false
     };
 
-    // Array of channels (like a JavaScript array or Python list)
-    // This will be populated from Rust with data from the SR API
+    // Tab management (0=Live, 1=Podcasts, 2=News, 3=Music)
+    in-out property <int> current-tab: 0;
+
+    // Data arrays for different tabs
     in-out property <[ChannelItem]> channels: [];
+    in-out property <[ProgramItem]> programs: [];  // For Podcasts tab
+    in-out property <[ProgramItem]> news-programs: [];  // For News tab
+    in-out property <[EpisodeItem]> episodes: [];
 
-    // CALLBACKS (like JavaScript event handlers or Python callback functions)
-    // These are called when user interacts with the UI
-    // The actual implementation is in Rust
+    // View state for Podcasts/News tabs
+    in-out property <string> selected-program-name: "";
+    in-out property <int> selected-program-id: 0;
+    in-out property <bool> show-episodes-view: false;
+    in-out property <bool> programs-loaded: false;
+    in-out property <bool> news-loaded: false;
 
-    // Called when user clicks on a channel
-    // Like: onClick={(id, url) => { ... }} in React
-    callback channel-selected(int, string);  // Parameters: (channel_id, stream_url)
+    // ================================================================
+    // CALLBACKS (Event Handlers)
+    // ================================================================
 
-    // Called when user clicks stop
+    // Channel selection (Live tab)
+    callback channel-selected(int, string);  // (channel_id, stream_url)
+
+    // Playback controls
     callback stop-clicked();
 
-    // Window properties
-    title: "SR Player - Sveriges Radio";
-    preferred-width: 800px;
-    preferred-height: 600px;
-    background: #1a1a1a;
+    // Program browsing
+    callback browse-podcasts-clicked(int);  // (program_id)
+    callback program-selected(int);         // (program_id)
+    callback episode-selected(int);         // (episode_id)
+    callback back-to-programs-clicked();
 
-    // Main layout - vertical arrangement of elements
-    // Like <div style="display: flex; flex-direction: column"> in CSS
+    // Tab navigation
+    callback podcasts-tab-clicked();
+    callback news-tab-clicked();
+
+    // Group expansion (for P4 Local News, Ekot News)
+    callback group-toggled(int);  // (group_id)
+
+    // Pagination (if needed)
+    callback load-more-programs();
+
+    // ================================================================
+    // MAIN LAYOUT
+    // ================================================================
     VerticalBox {
         padding: 16px;
         spacing: 12px;
 
         // ================================================================
-        // HEADER SECTION
-        // ================================================================
-        // HorizontalBox {
-        //     alignment: center;
-
-        //     Text {
-        //         text: "SR Player";
-        //         font-size: 24px;
-        //         font-weight: 700;
-        //         color: #ffffff;
-        //     }
-        // }
-
-        // ================================================================
         // NOW PLAYING SECTION
         // ================================================================
-        Rectangle {
-            background: #2a2a2a;
-            border-radius: 8px;
-            min-height: 180px;
+        NowPlaying {
+            current-channel-name: root.current-channel-name;
+            is-playing: root.is-playing;
+            is-loading: root.is-loading;
+            current-program: root.current-program;
 
-            VerticalBox {
-                padding: 16px;
-                spacing: 8px;
+            browse-podcasts-clicked(program-id) => {
+                root.browse-podcasts-clicked(program-id);
+            }
 
-                Text {
-                    text: "Now Playing";
-                    font-size: 14px;
-                    color: #888888;
-                }
-
-                Text {
-                    // Shows current channel name, or "No channel selected"
-                    text: current-channel-name;
-                    font-size: 18px;
-                    font-weight: 600;
-                    color: #ffffff;
-                }
-
-                // Status indicator
-                Text {
-                    // Conditional text - like JavaScript ternary operator:
-                    // is_playing ? "Playing..." : "Stopped"
-                    text: is-loading ? "Loading..." :
-                          is-playing ? "▶ Playing..." : "⏸ Stopped";
-                    font-size: 14px;
-                    color: is-playing ? #4CAF50 : #888888;  // Green if playing, gray if not
-                }
-
-                // Show program information if available
-                if current-program.title != "": HorizontalBox {
-                    spacing: 12px;
-                    padding-top: 8px;
-
-                    // Show image to the left of program info
-                    Image {
-                        source: current-program.show-image;
-                        width: 80px;
-                        height: 80px;
-                        image-fit: cover;
-                    }
-
-                    VerticalBox {
-                        spacing: 6px;
-
-                        // Program title
-                        Text {
-                            text: current-program.title;
-                            font-size: 16px;
-                            font-weight: 600;
-                            color: #e0e0e0;
-                        }
-
-                        // Time range
-                        if current-program.start-time != "": Text {
-                            text: current-program.start-time + " - " + current-program.end-time;
-                            font-size: 13px;
-                            color: #aaaaaa;
-                        }
-
-                        // Program description
-                        if current-program.description != "": Text {
-                            text: current-program.description;
-                            font-size: 12px;
-                            color: #999999;
-                            wrap: word-wrap;
-                            overflow: elide;
-                            max-height: 40px;
-                        }
-                    }
-                }
+            stop-clicked => {
+                root.stop-clicked();
             }
         }
 
@@ -194,75 +136,133 @@ export component MainWindow inherits Window {
             spacing: 8px;
             alignment: center;
 
-            // Stop button
+            // Stop button (only enabled when playing)
             Button {
                 text: "Stop";
                 enabled: is-playing && !is-loading;
-
                 clicked => {
                     stop-clicked();
                 }
             }
-        }
 
-        // ================================================================
-        // CHANNEL LIST
-        // ================================================================
-        Text {
-            text: "Available Channels";
-            font-size: 16px;
-            font-weight: 600;
-            color: #ffffff;
-        }
-
-        // Scrollable list of channels
-        // Like <div style="overflow-y: scroll"> in HTML
-        ScrollView {
-            // Use remaining vertical space
-            vertical-stretch: 1;
-
-            // ListView is like map() in React:
-            // channels.map(channel => <ChannelListItem channel={channel} />)
-            VerticalLayout {
-                spacing: 4px;
-
-                // For each channel in the channels array, create a button
-                for channel in channels: Rectangle {
-                    height: 50px;
-                    background: channel-touch.has-hover ? #3a3a3a : #2a2a2a;
-                    border-radius: 4px;
-
-                    // TouchArea makes the rectangle clickable
-                    // Like adding onClick to a div in React
-                    channel-touch := TouchArea {
-                        clicked => {
-                            // When clicked, call the callback with channel data
-                            channel-selected(channel.id, channel.stream-url);
-                        }
-                    }
-
-                    HorizontalBox {
-                        padding: 12px;
-                        spacing: 8px;
-
-                        Text {
-                            text: channel.name;
-                            font-size: 16px;
-                            color: #ffffff;
-                            vertical-alignment: center;
-                        }
-                    }
-                }
-
-                // Show message if no channels loaded
-                if channels.length == 0: Text {
-                    text: "Loading channels...";
-                    color: #888888;
-                    horizontal-alignment: center;
-                    vertical-alignment: center;
+            // Browse Podcasts button (only shown when current program has podcasts)
+            if current-program.has-podcasts && current-program.program-id > 0: Button {
+                text: "Browse Podcasts";
+                clicked => {
+                    browse-podcasts-clicked(current-program.program-id);
                 }
             }
         }
 
+        // ================================================================
+        // TAB NAVIGATION
+        // ================================================================
+        TabBar {
+            current-tab <=> root.current-tab;  // Two-way binding
+
+            tab-clicked(tab-id) => {
+                // Handle special logic for specific tabs
+                if (tab-id == 1) {
+                    // Podcasts tab
+                    show-episodes-view = false;
+                    podcasts-tab-clicked();
+                } else if (tab-id == 2) {
+                    // News tab
+                    news-tab-clicked();
+                }
+                // For Live (0) and Music (3), just switching the tab is enough
+            }
+        }
+
+        // ================================================================
+        // TAB CONTENT AREA
+        // ================================================================
+
+        // Live Tab - Channel list
+        if current-tab == 0: TabContent {
+            is-channels-tab: true;
+            channels: root.channels;
+            is-loaded: true;
+            loading-text: "Loading channels...";
+            empty-text: "No channels found";
+
+            channel-selected(id, url) => {
+                root.channel-selected(id, url);
+            }
+        }
+
+        // Podcasts Tab - Programs list or episodes
+        if current-tab == 1: TabContent {
+            // Switch between programs list and episodes view
+            show-back-button: show-episodes-view;
+            selected-program-name: root.selected-program-name;
+
+            // Show either programs or episodes
+            is-programs-tab: !show-episodes-view;
+            is-episodes-tab: show-episodes-view;
+
+            programs: root.programs;
+            episodes: root.episodes;
+            is-loaded: programs-loaded;
+            loading-text: "Loading programs...";
+            empty-text: show-episodes-view ? "No episodes found" : "No programs found";
+
+            program-selected(id) => {
+                root.program-selected(id);
+            }
+
+            group-toggled(id) => {
+                root.group-toggled(id);
+            }
+
+            episode-selected(id) => {
+                root.episode-selected(id);
+            }
+
+            back-clicked => {
+                root.back-to-programs-clicked();
+            }
+        }
+
+        // News Tab - News programs with groups (same structure as Podcasts)
+        if current-tab == 2: TabContent {
+            // Switch between programs list and episodes view
+            show-back-button: show-episodes-view;
+            selected-program-name: root.selected-program-name;
+
+            // Show either programs or episodes
+            is-programs-tab: !show-episodes-view;
+            is-episodes-tab: show-episodes-view;
+
+            programs: root.news-programs;
+            episodes: root.episodes;
+            is-loaded: news-loaded;
+            loading-text: "Loading news programs...";
+            empty-text: show-episodes-view ? "No episodes found" : "No news programs found";
+
+            program-selected(id) => {
+                root.program-selected(id);
+            }
+
+            group-toggled(id) => {
+                root.group-toggled(id);
+            }
+
+            episode-selected(id) => {
+                root.episode-selected(id);
+            }
+
+            back-clicked => {
+                root.back-to-programs-clicked();
+            }
+        }
+
+        // Music Tab - Placeholder using TabContent
+        if current-tab == 3: TabContent {
+            show-simple-text: true;
+            simple-text: "Music content coming soon...";
+            simple-text-color: #888888;
+            is-loaded: true;
+        }
     }
 }

--- a/src/ui/main.slint
+++ b/src/ui/main.slint
@@ -44,6 +44,7 @@ export struct ProgramInfo {
     description: string,     // Program description
     start-time: string,      // Start time (formatted)
     end-time: string,        // End time (formatted)
+    show-image: image,       // Show image (loaded from URL)
 }
 
 // Main application window component
@@ -60,7 +61,8 @@ export component MainWindow inherits Window {
         title: "",
         description: "",
         start-time: "",
-        end-time: ""
+        end-time: "",
+        show-image: @image-url("")
     };
 
     // Array of channels (like a JavaScript array or Python list)
@@ -93,16 +95,16 @@ export component MainWindow inherits Window {
         // ================================================================
         // HEADER SECTION
         // ================================================================
-        HorizontalBox {
-            alignment: center;
+        // HorizontalBox {
+        //     alignment: center;
 
-            Text {
-                text: "SR Player";
-                font-size: 24px;
-                font-weight: 700;
-                color: #ffffff;
-            }
-        }
+        //     Text {
+        //         text: "SR Player";
+        //         font-size: 24px;
+        //         font-weight: 700;
+        //         color: #ffffff;
+        //     }
+        // }
 
         // ================================================================
         // NOW PLAYING SECTION
@@ -141,33 +143,45 @@ export component MainWindow inherits Window {
                 }
 
                 // Show program information if available
-                if current-program.title != "": VerticalBox {
-                    spacing: 6px;
+                if current-program.title != "": HorizontalBox {
+                    spacing: 12px;
                     padding-top: 8px;
 
-                    // Program title
-                    Text {
-                        text: current-program.title;
-                        font-size: 16px;
-                        font-weight: 600;
-                        color: #e0e0e0;
+                    // Show image to the left of program info
+                    Image {
+                        source: current-program.show-image;
+                        width: 80px;
+                        height: 80px;
+                        image-fit: cover;
                     }
 
-                    // Time range
-                    if current-program.start-time != "": Text {
-                        text: current-program.start-time + " - " + current-program.end-time;
-                        font-size: 13px;
-                        color: #aaaaaa;
-                    }
+                    VerticalBox {
+                        spacing: 6px;
 
-                    // Program description
-                    if current-program.description != "": Text {
-                        text: current-program.description;
-                        font-size: 12px;
-                        color: #999999;
-                        wrap: word-wrap;
-                        overflow: elide;
-                        max-height: 40px;
+                        // Program title
+                        Text {
+                            text: current-program.title;
+                            font-size: 16px;
+                            font-weight: 600;
+                            color: #e0e0e0;
+                        }
+
+                        // Time range
+                        if current-program.start-time != "": Text {
+                            text: current-program.start-time + " - " + current-program.end-time;
+                            font-size: 13px;
+                            color: #aaaaaa;
+                        }
+
+                        // Program description
+                        if current-program.description != "": Text {
+                            text: current-program.description;
+                            font-size: 12px;
+                            color: #999999;
+                            wrap: word-wrap;
+                            overflow: elide;
+                            max-height: 40px;
+                        }
                     }
                 }
             }

--- a/src/ui/now_playing.slint
+++ b/src/ui/now_playing.slint
@@ -1,0 +1,120 @@
+// NowPlaying Component - Displays currently playing channel and program information
+// This component shows:
+// - The current channel name
+// - Playing/stopped/loading status
+// - Current program details (when available)
+// - Program image, title, time, and description
+
+import { VerticalBox, HorizontalBox } from "std-widgets.slint";
+import { ProgramInfo } from "types.slint";
+
+export component NowPlaying inherits Rectangle {
+    // ================================================================
+    // PROPERTIES
+    // ================================================================
+
+    // Current channel being played (or "No channel selected")
+    in-out property <string> current-channel-name: "No channel selected";
+
+    // Playback state flags
+    in-out property <bool> is-playing: false;
+    in-out property <bool> is-loading: false;
+
+    // Current program information (populated when a channel is playing)
+    in-out property <ProgramInfo> current-program;
+
+    // ================================================================
+    // CALLBACKS
+    // ================================================================
+
+    // Called when user clicks "Browse Podcasts" button for current program
+    callback browse-podcasts-clicked(int);  // Parameters: (program_id)
+
+    // Called when user clicks "Stop" button
+    callback stop-clicked();
+
+    // ================================================================
+    // VISUAL STYLING
+    // ================================================================
+    background: #2a2a2a;
+    border-radius: 8px;
+    min-height: 180px;
+
+    // ================================================================
+    // LAYOUT
+    // ================================================================
+    VerticalBox {
+        padding: 16px;
+        spacing: 8px;
+
+        // Section title
+        Text {
+            text: "Now Playing";
+            font-size: 14px;
+            color: #888888;
+        }
+
+        // Channel name (main text)
+        Text {
+            text: current-channel-name;
+            font-size: 18px;
+            font-weight: 600;
+            color: #ffffff;
+        }
+
+        // Status indicator - shows different states:
+        // - "Loading..." when buffering
+        // - "▶ Playing..." when active
+        // - "⏸ Stopped" when inactive
+        Text {
+            text: is-loading ? "Loading..." :
+                  is-playing ? "▶ Playing..." : "⏸ Stopped";
+            font-size: 14px;
+            color: is-playing ? #4CAF50 : #888888;  // Green when playing, gray otherwise
+        }
+
+        // Program information section (only visible when program data exists)
+        if current-program.title != "": HorizontalBox {
+            spacing: 12px;
+            padding-top: 8px;
+
+            // Program image/thumbnail
+            Image {
+                source: current-program.show-image;
+                width: 80px;
+                height: 80px;
+                image-fit: cover;  // Ensures image fills the space without distortion
+            }
+
+            // Program text details
+            VerticalBox {
+                spacing: 6px;
+
+                // Program title
+                Text {
+                    text: current-program.title;
+                    font-size: 16px;
+                    font-weight: 600;
+                    color: #e0e0e0;
+                }
+
+                // Time range (e.g., "09:00 - 12:00")
+                if current-program.start-time != "": Text {
+                    text: current-program.start-time + " - " + current-program.end-time;
+                    font-size: 13px;
+                    color: #aaaaaa;
+                }
+
+                // Program description (truncated if too long)
+                if current-program.description != "": Text {
+                    text: current-program.description;
+                    font-size: 12px;
+                    color: #999999;
+                    wrap: word-wrap;      // Allow text to wrap to multiple lines
+                    overflow: elide;      // Add "..." if text is too long
+                    max-height: 40px;     // Limit to ~3 lines of text
+                }
+            }
+        }
+    }
+}

--- a/src/ui/tab_bar.slint
+++ b/src/ui/tab_bar.slint
@@ -1,0 +1,78 @@
+// TabBar Component - Reusable tab navigation bar
+//
+// This component creates a horizontal row of tabs with:
+// - Dynamic tab generation from a list
+// - Active/inactive styling
+// - Click handling for tab selection
+//
+// Usage: Pass an array of tab names and handle the tab-clicked callback
+
+import { HorizontalBox } from "std-widgets.slint";
+
+// Data structure for a single tab
+export struct TabItem {
+    id: int,           // Tab index (0, 1, 2, 3, etc.)
+    label: string,     // Tab display text ("Live", "Podcasts", etc.)
+}
+
+// TabBar component that generates tabs from a list
+export component TabBar inherits Rectangle {
+    // ================================================================
+    // PROPERTIES
+    // ================================================================
+
+    // Current active tab index
+    in-out property <int> current-tab: 0;
+
+    // List of tabs to display
+    in property <[TabItem]> tabs: [
+        { id: 0, label: "Live" },
+        { id: 1, label: "Podcasts" },
+        { id: 2, label: "News" },
+        { id: 3, label: "Music" }
+    ];
+
+    // Visual properties
+    in property <color> active-background: #3a3a3a;
+    in property <color> inactive-background: #2a2a2a;
+    in property <color> text-color: #ffffff;
+    in property <int> tab-height: 60;
+
+    // ================================================================
+    // CALLBACKS
+    // ================================================================
+
+    // Called when any tab is clicked
+    callback tab-clicked(int);  // Parameters: (tab_id)
+
+    // ================================================================
+    // LAYOUT
+    // ================================================================
+
+    height: tab-height * 1px;
+
+    HorizontalBox {
+        spacing: 0px;
+
+        // Generate tabs dynamically from the tabs array
+        for tab[index] in tabs: Rectangle {
+            horizontal-stretch: 1;
+            background: current-tab == tab.id ? active-background : inactive-background;
+
+            TouchArea {
+                clicked => {
+                    current-tab = tab.id;
+                    root.tab-clicked(tab.id);
+                }
+            }
+
+            Text {
+                text: tab.label;
+                font-size: 14px;
+                color: text-color;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+        }
+    }
+}

--- a/src/ui/tab_content.slint
+++ b/src/ui/tab_content.slint
@@ -1,0 +1,349 @@
+// TabContent Component - A reusable component for Live, Podcasts, News, and Music tabs
+// This component provides a consistent layout for all content tabs with:
+// - A title header
+// - A scrollable list of items
+// - Support for different item types (channels, programs, episodes)
+// - Hover effects and click handling
+// - Empty/loading states
+// - Support for simple text content (Music tab placeholder)
+
+import { Button, VerticalBox, HorizontalBox, ScrollView } from "std-widgets.slint";
+import { ChannelItem, ProgramItem, EpisodeItem } from "types.slint";
+
+// Generic list item component that can display channels, programs, or episodes
+component ListItem inherits Rectangle {
+    // ================================================================
+    // PROPERTIES
+    // ================================================================
+
+    // Visual properties
+    in property <bool> has-hover: false;
+    in property <int> item-height: 50;
+    in property <color> background-color: has-hover ? #3a3a3a : #2a2a2a;
+
+    // Content properties for different item types
+    in property <string> title: "";
+    in property <string> subtitle: "";
+    in property <bool> is-group: false;
+    in property <bool> is-child: false;
+    in property <bool> is-expanded: false;
+    in property <string> expand-icon: "▶";
+
+    // ================================================================
+    // CALLBACKS
+    // ================================================================
+    callback clicked();
+
+    // ================================================================
+    // VISUAL STYLING
+    // ================================================================
+    min-height: item-height * 1px;
+    background: background-color;
+    border-radius: 4px;
+
+    // Touch area for click detection
+    touch-area := TouchArea {
+        clicked => { root.clicked(); }
+    }
+
+    // ================================================================
+    // LAYOUT
+    // ================================================================
+    HorizontalBox {
+        padding-left: 12px;
+        padding-right: 12px;
+        padding-top: 0px;
+        padding-bottom: 0px;
+        spacing: 8px;
+
+        // Expansion indicator for collapsible groups (P4 Local News, Ekot News)
+        if is-group: Text {
+            text: expand-icon;
+            font-size: 12px;
+            color: #aaaaaa;
+            vertical-alignment: center;
+        }
+
+        // Main content area
+        VerticalLayout {
+            spacing: 2px;
+            alignment: center;
+
+            // Title with indentation for child items
+            Text {
+                text: is-child ? "  " + title : title;
+                font-size: is-group ? 16px : 14px;
+                font-weight: is-group ? 700 : 600;
+                color: is-group ? #ffffff : (is-child ? #e0e0e0 : #ffffff);
+            }
+
+            // Optional subtitle (for descriptions, dates, etc.)
+            if subtitle != "": Text {
+                text: subtitle;
+                font-size: 11px;
+                color: #aaaaaa;
+            }
+        }
+    }
+}
+
+// Main TabContent component
+export component TabContent inherits VerticalBox {
+    // ================================================================
+    // PROPERTIES
+    // ================================================================
+
+
+    // Content type flags (determines which list to show)
+    in property <bool> is-channels-tab: false;
+    in property <bool> is-programs-tab: false;
+    in property <bool> is-episodes-tab: false;
+
+    // Data arrays for different content types
+    in property <[ChannelItem]> channels: [];
+    in property <[ProgramItem]> programs: [];
+    in property <[EpisodeItem]> episodes: [];
+
+    // Loading and empty states
+    in property <bool> is-loaded: false;
+    in property <string> loading-text: "Loading...";
+    in property <string> empty-text: "No items found";
+
+    // Special properties for episodes view
+    in property <bool> show-back-button: false;
+    in property <string> selected-program-name: "";
+
+    // Simple text content (for placeholder tabs like Music)
+    in property <bool> show-simple-text: false;
+    in property <string> simple-text: "";
+    in property <color> simple-text-color: #888888;
+
+    // ================================================================
+    // CALLBACKS
+    // ================================================================
+
+    // Channel selection callback
+    callback channel-selected(int, string);  // Parameters: (channel_id, stream_url)
+
+    // Program selection and group toggle callbacks
+    callback program-selected(int);  // Parameters: (program_id)
+    callback group-toggled(int);     // Parameters: (group_id)
+
+    // Episode selection callback
+    callback episode-selected(int);  // Parameters: (episode_id)
+
+    // Navigation callback for episodes view
+    callback back-clicked();
+
+    // Helper function to format duration from seconds to MM:SS or HH:MM:SS
+    pure function format-duration(seconds: int) -> string {
+        if seconds < 3600 {
+            return Math.floor(seconds / 60) + ":" + Math.mod(seconds, 60);
+        } else {
+            return Math.floor(seconds / 3600) + ":" + Math.floor(Math.mod(seconds, 3600) / 60) + ":" + Math.mod(seconds, 60);
+        }
+    }
+
+    // ================================================================
+    // LAYOUT
+    // ================================================================
+    spacing: 8px;
+    vertical-stretch: 1;
+
+    // Header section with back button and program name (for episodes view only)
+    if show-back-button: HorizontalBox {
+        spacing: 8px;
+        alignment: start;
+
+        // Back button for episodes view
+        Button {
+            text: "← Back";
+            clicked => { back-clicked(); }
+        }
+
+        // Selected program name
+        Text {
+            text: selected-program-name;
+            font-size: 16px;
+            font-weight: 600;
+            color: #ffffff;
+            vertical-alignment: center;
+        }
+    }
+
+    // ================================================================
+    // CHANNELS SCROLLVIEW (Live Tab)
+    // ================================================================
+    if is-channels-tab: ScrollView {
+        vertical-stretch: 1;
+
+        VerticalLayout {
+            spacing: 4px;
+
+            for channel[index] in channels: ListItem {
+                title: channel.name;
+                has-hover: channel-touch.has-hover;
+
+                channel-touch := TouchArea {
+                    clicked => {
+                        channel-selected(channel.id, channel.stream-url);
+                    }
+                }
+            }
+
+            if channels.length == 0 && is-loaded: Text {
+                text: empty-text;
+                color: #888888;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+
+            if !is-loaded: Text {
+                text: loading-text;
+                color: #888888;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+        }
+    }
+
+    // ================================================================
+    // PROGRAMS SCROLLVIEW (Podcasts and News Tabs)
+    // ================================================================
+    if is-programs-tab: ScrollView {
+        vertical-stretch: 1;
+
+        VerticalLayout {
+            spacing: 4px;
+
+            for program[index] in programs: ListItem {
+                visible: program.is-expanded;
+                title: program.name;
+                subtitle: program.is-group ? program.description : "";
+                is-group: program.is-group;
+                is-child: program.is-child;
+                expand-icon: program.group-expanded ? "▼" : "▶";
+                item-height: program.is-group ? 60 : 50;
+                has-hover: program-touch.has-hover;
+
+                program-touch := TouchArea {
+                    clicked => {
+                        if (program.is-group) {
+                            group-toggled(program.id);
+                        } else {
+                            program-selected(program.id);
+                        }
+                    }
+                }
+            }
+
+            if programs.length == 0 && is-loaded: Text {
+                text: empty-text;
+                color: #888888;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+
+            if !is-loaded: Text {
+                text: loading-text;
+                color: #888888;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+        }
+    }
+
+    // ================================================================
+    // EPISODES SCROLLVIEW (Individual Program View)
+    // ================================================================
+    if is-episodes-tab: ScrollView {
+        vertical-stretch: 1;
+
+        VerticalLayout {
+            spacing: 4px;
+
+            for episode[index] in episodes: Rectangle {
+                background: episode-touch.has-hover ? #3a3a3a : #2a2a2a;
+                border-radius: 4px;
+
+                episode-touch := TouchArea {
+                    clicked => {
+                        episode-selected(episode.id);
+                    }
+                }
+
+                VerticalBox {
+                    padding: 12px;
+                    spacing: 6px;
+
+                    Text {
+                        text: episode.title;
+                        font-size: 14px;
+                        font-weight: 600;
+                        color: #ffffff;
+                    }
+
+                    HorizontalBox {
+                        spacing: 12px;
+
+                        Text {
+                            text: episode.publish-date;
+                            font-size: 11px;
+                            color: #aaaaaa;
+                        }
+
+                        Text {
+                            text: format-duration(episode.duration);
+                            font-size: 11px;
+                            color: #aaaaaa;
+                        }
+
+                        Text {
+                            text: episode.file-size;
+                            font-size: 11px;
+                            color: #888888;
+                        }
+                    }
+
+                    if episode.description != "": Text {
+                        text: episode.description;
+                        font-size: 11px;
+                        color: #999999;
+                        wrap: word-wrap;
+                        overflow: elide;
+                        max-height: 32px;
+                    }
+                }
+            }
+
+            if episodes.length == 0 && is-loaded: Text {
+                text: empty-text;
+                color: #888888;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+
+            if !is-loaded: Text {
+                text: loading-text;
+                color: #888888;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+        }
+    }
+
+    // ================================================================
+    // SIMPLE TEXT CONTENT (for placeholder tabs like Music)
+    // ================================================================
+    if show-simple-text: VerticalBox {
+        vertical-stretch: 1;
+
+        Text {
+            text: simple-text;
+            font-size: 14px;
+            color: simple-text-color;
+            horizontal-alignment: center;
+            vertical-alignment: center;
+        }
+    }
+}

--- a/src/ui/types.slint
+++ b/src/ui/types.slint
@@ -1,0 +1,64 @@
+// Shared type definitions for SR Player
+//
+// This file contains all the data structures (structs) used across components.
+// By keeping them in a separate file, we avoid circular dependencies.
+//
+// These structs are like TypeScript interfaces or Python dataclasses,
+// defining the shape of data passed between components.
+
+// ================================================================
+// CHANNEL DATA
+// ================================================================
+
+// Represents a radio channel in the Live tab
+export struct ChannelItem {
+    id: int,               // Channel ID (e.g., 132 for SR P1)
+    name: string,          // Channel display name (e.g., "SR P1")
+    stream-url: string,    // URL to the MP3 stream
+}
+
+// ================================================================
+// PROGRAM DATA
+// ================================================================
+
+// Information about the currently playing program
+export struct ProgramInfo {
+    title: string,         // Current program title
+    description: string,   // Program description
+    start-time: string,    // Start time (formatted as "HH:MM")
+    end-time: string,      // End time (formatted as "HH:MM")
+    show-image: image,     // Program thumbnail/image
+    program-id: int,       // Unique program ID for API calls
+    has-podcasts: bool,    // Whether this program has podcast episodes
+}
+
+// Represents a program with podcast episodes
+export struct ProgramItem {
+    id: int,                   // Program ID
+    name: string,              // Program name
+    description: string,       // Program description
+    image: image,              // Program logo/image
+    has-pod: bool,             // Has podcast episodes
+
+    // Group-related properties (for collapsible sections like P4 Local News)
+    is-group: bool,            // True if this is a group header
+    is-expanded: bool,         // True if item should be visible
+    is-child: bool,            // True if this is a child of a group
+    group-id: int,             // ID of parent group (0 if not a child)
+    group-expanded: bool,      // True if parent group is expanded
+}
+
+// ================================================================
+// EPISODE DATA
+// ================================================================
+
+// Represents a single podcast episode
+export struct EpisodeItem {
+    id: int,                   // Episode ID
+    title: string,             // Episode title
+    description: string,       // Episode description/summary
+    duration: int,             // Duration in seconds
+    publish-date: string,      // Formatted publish date (e.g., "11 Aug 2020")
+    url: string,               // MP3 file URL for streaming
+    file-size: string,         // Formatted file size (e.g., "9.2 MB")
+}


### PR DESCRIPTION
Major UI Refactoring & Podcasts:
- Split monolithic main.slint into reusable components (NowPlaying, TabContent, TabBar)
- Move type definitions to separate types.slint file
- Extract channel list, program list, and episode list into generic TabContent component
- Create dedicated NowPlaying component with program info and artwork display

New Features:
- Multi-tab navigation: Live, Podcasts, News, Music
- Collapsible groups for P4 Local News and Ekot News programs
- Episode browsing with back navigation
- "Browse Podcasts" button when listening to programs with available podcasts

Window Updates:
- Reduce dimensions to 360x600 (mobile-friendly portrait layout)
- Adjust minimum size to 300x300 for smaller screens

Component Architecture:
- types.slint: Shared data structures (ChannelItem, ProgramInfo, ProgramItem, EpisodeItem)
- now_playing.slint: Current playback status and program information display
- tab_content.slint: Generic content renderer for all tabs (channels/programs/episodes)
- tab_bar.slint: Tab navigation component
- main.slint: Orchestrator that wires everything together


Build & CI/CD:
- Add build matrix with platform-specific targets:
  * macOS: x86_64-apple-darwin (cargo-bundle for .app)
  * Linux: x86_64-unknown-linux-gnu (tar.gz with binary + README)
  * Windows: x86_64-pc-windows-msvc (zip with .exe + README)
- Install Linux build dependencies conditionally
- Create platform-specific packages with version-tagged filenames
- Upload all artifacts from each platform
- Add separate create-release job to collect all artifacts and create GitHub release
- Update release notes with installation instructions for all platforms
- List all three platform packages as release assets

Release artifacts naming:
- macOS: SR-Player-{version}-macos.zip
- Linux: sr-player-{version}-linux.tar.gz
- Windows: sr-player-{version}-windows.zip